### PR TITLE
chore: migrate FinAgent from OpenRouter to NVIDIA NIM with parallel LangGraph pipeline

### DIFF
--- a/finagent/.env.example
+++ b/finagent/.env.example
@@ -1,0 +1,25 @@
+# =============================================================================
+# FinAgent Environment Configuration Template
+# Copy this file to `.env` and fill in real credentials.
+# All keys are free-tier on NVIDIA's API trial when paired with the open-weight
+# fallback listed below.
+# =============================================================================
+
+# -------- Storage ------------------------------------------------------------
+DATABASE_URL=postgresql+asyncpg://finagent:finagent_secure_pass@localhost:5432/finagent
+
+# -------- LLM providers -------------------------------------------------------
+# NVIDIA: primary + fallback model (free on trial tier).
+# Primary is preferred; fallback is invoked automatically when a NotFoundError
+# (private NIM not provisioned for the account) is returned by the primary.
+NVIDIA_API_KEY=nvapi-XXX
+NVIDIA_BASE_URL=https://integrate.api.nvidia.com/v1
+NVIDIA_MODEL=openai/gpt-oss-120b
+NVIDIA_FALLBACK_MODEL=meta/llama-3.1-70b-instruct
+
+# Search grounding
+TAVILY_API_KEY=tvly-XXX
+
+# LangSmith observability
+LANGCHAIN_TRACING_V2=true
+LANGCHAIN_API_KEY=lsv2_pt_XXX

--- a/finagent/agents_scripts/run_live_editor.py
+++ b/finagent/agents_scripts/run_live_editor.py
@@ -13,7 +13,7 @@ from app.agents.risk import risk_agent_node
 from app.agents.editor import editor_agent_node
 
 async def run_live_editor_pipeline():
-    print("🚀 Initializing Live Multi-Agent Pipeline for PETR4...")
+    print("[INIT] Initializing Live Multi-Agent Pipeline for PETR4...")
     state = create_initial_state(
         pipeline_run_id="live-editor-smoke-test",
         morning_note_id=f"note-{int(datetime.now().timestamp())}",
@@ -22,27 +22,27 @@ async def run_live_editor_pipeline():
     )
     
     # Step 1: Ingest Live Data Feeds
-    print("\n📥 Phase 1: Ingesting upstream live metrics & analysis...")
+    print("\n[PHASE 1] Ingesting upstream live metrics & analysis...")
     state = macro_agent_node(state)
     state = company_agent_node(state)
     state = quant_agent_node(state)
     
     # Step 2: Extract Adversarial Vulnerabilities
-    print("\n⚔️ Phase 2: Auditing risks and data integrity gaps...")
+    print("\n[PHASE 2] Auditing risks and data integrity gaps...")
     state = risk_agent_node(state)
     
     # Step 3: Compile Editorial Layout and Typed Allocation
-    print("\n✍️ Phase 3: Executing EditorAgent compilation layer...")
+    print("\n[PHASE 3] Executing EditorAgent compilation layer...")
     final_state = editor_agent_node(state)
     
-    print("\n🎯 --- LIVE DELIVERABLE RESULTS ---")
-    
-    print("\n📊 [SECTION CONFIDENCE SCORES]")
+    print("\n[RESULTS] --- LIVE DELIVERABLE RESULTS ---")
+
+    print("\n[SECTION CONFIDENCE SCORES]")
     for section, score in final_state.get("confidence_scores", {}).items():
-        status = "🟢 SOLID" if score >= 0.5 else "🔴 COMPROMISED (GAP DETECTED)"
+        status = "[SOLID]" if score >= 0.5 else "[GAP DETECTED]"
         print(f" - {section.upper()}: {score} | {status}")
-        
-    print("\n💼 [TYPED INVESTMENT RECOMMENDATION STRUCT]")
+
+    print("\n[TYPED INVESTMENT RECOMMENDATION STRUCT]")
     rec = final_state.get("recommendation")
     if rec:
         print(f" - Action: {rec.action}")
@@ -50,11 +50,11 @@ async def run_live_editor_pipeline():
         print(f" - View Horizon: {rec.horizon_months} Months")
         print(f" - Thesis Summary Bullet: {rec.thesis_summary}")
     else:
-        print(" ❌ No structured recommendation generated.")
+        print(" [NONE] No structured recommendation generated.")
 
-    print("\n📝 [GENERATED MORNING NOTE NARRATIVE]")
+    print("\n[GENERATED MORNING NOTE NARRATIVE]")
     print("--------------------------------------------------------------------------------")
-    print(final_state.get("morning_note") or "❌ Morning note is empty/failed.")
+    print(final_state.get("morning_note") or "[EMPTY] Morning note is empty/failed.")
     print("--------------------------------------------------------------------------------")
 
 if __name__ == "__main__":

--- a/finagent/agents_scripts/run_pipeline.py
+++ b/finagent/agents_scripts/run_pipeline.py
@@ -1,0 +1,105 @@
+import os
+import sys
+import uuid
+import time
+from datetime import datetime, timezone
+from dotenv import load_dotenv
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# Ensure console can render UTF-8 payloads emitted by upstream LLMs (e.g. \u202f).
+try:
+    sys.stdout.reconfigure(encoding="utf-8")
+    sys.stderr.reconfigure(encoding="utf-8")
+except Exception:
+    pass
+
+load_dotenv()
+
+from app.graph.state import create_initial_state
+from app.graph.pipeline import run_financial_pipeline
+
+def main():
+    print('='*70)
+    print("INITIALIZING MULTI-AGENT ANALYSIS PIPELINE: FINAGENT ENGINE")
+    print('='*70)
+
+    if not os.getenv("NVIDIA_API_KEY") or not os.getenv("TAVILY_API_KEY"):
+        print("Environment keys missing")
+        sys.exit(1)
+
+    run_id = f"run-{uuid.uuid4().hex[:8]}"
+    note_id = f"note-{uuid.uuid4().hex[:8]}"
+
+    print(f"[*] Correlation Tracking: run_id={run_id} | note_id={note_id}")
+    print("[*] Target Analysis Ticker: PETR4")
+
+    state = create_initial_state(
+        pipeline_run_id=run_id,
+        morning_note_id=note_id,
+        manager_id=1,
+        company_ticker="PETR4"
+    )
+
+    state["data_freshness"]["company"] = datetime.now(timezone.utc).isoformat()
+
+    try:
+        print("[*] Launching execution loops across LangGraph topology...")
+        
+        start_time = time.perf_counter()
+        
+        final_output = run_financial_pipeline(state)
+        
+        end_time = time.perf_counter()
+        execution_duration = end_time - start_time
+        
+        print("\n" + "="*50)
+        print("DELIVERABLE NARRATIVE REPORT (EDITOR_AGENT CONSOLIDATION)")
+        print("="*50)
+
+        if final_output.get("morning_note"):
+            print(final_output["morning_note"])
+        else:
+            print("WARNING: Empty narrative block output emitted.")
+
+        rec = final_output.get("recommendation")
+        if rec:
+            print("\n" + "-" * 50)
+            print("STRUCTURAL METRIC RECOMMENDATION:")
+            print(f"   Target Action:       {rec.action}")
+            print(f"   Recommended Weight:  {rec.target_weight}%")
+            print(f"   Investment Horizon:  {rec.horizon_months} Months")
+            print(f"   Thesis Overview:     {rec.thesis_summary}")
+            print("-" * 50)
+
+        # Print execution duration regardless of recommendation presence
+        print(f"\n⏱️ Pipeline execution completed in: {execution_duration:.2f} seconds")
+
+        # --- DEDUPLICATED FLAG DISPLAY LOGIC ---
+        flags = final_output.get("flags", [])
+        if flags:
+            unique_flags = {}
+            for flag in flags:
+                flag_msg = getattr(flag, "message", None)
+                if not flag_msg and hasattr(flag, "metadata") and isinstance(flag.metadata, dict):
+                    flag_msg = flag.metadata.get("error", "Unknown execution error context")
+                elif not flag_msg:
+                    flag_msg = "Unknown execution error context"
+                
+                dedup_key = (flag.source, flag.flag_type, flag_msg)
+                if dedup_key not in unique_flags:
+                    unique_flags[dedup_key] = (flag, flag_msg)
+
+            print(f"\nIncident Data Flags Detected ({len(unique_flags)} unique):")
+            for _, (flag, flag_msg) in unique_flags.items():
+                print(f"   - Source: {flag.source} | Grade: {flag.flag_type} | Reason: {flag_msg}")
+        else:
+            print("\nExecution Track Clean: No upstream data anomalies recorded.")
+
+    except Exception as e:
+        print(f"\nPipeline integration failure encountered: {str(e)}")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()
+    sys.exit(0)

--- a/finagent/app/agents/company.py
+++ b/finagent/app/agents/company.py
@@ -1,15 +1,15 @@
-import os
 import logging
+import os
 import re
 import json
 from datetime import datetime, timezone
 
-from openai import OpenAI
 from tavily import TavilyClient
 
+from app.core.config import get_llm_client, settings
 from app.graph.state import AgentState, CompanyEvent
-from app.utils.data_preprocessing import DataFlag
 from app.prompts.services.prompt_loader import PromptManagementService
+from app.utils.data_preprocessing import DataFlag
 
 MONTHS_PT = {
     1: "janeiro", 2: "fevereiro", 3: "março", 4: "abril",
@@ -26,11 +26,11 @@ def company_agent_node(state: AgentState) -> AgentState:
 
     logger.info(f"[{run_id}][{note_id}] Starting CompanyAgent analysis for {ticker}.")
 
-    openrouter_api_key = os.getenv("OPENROUTER_API_KEY")
-    tavily_api_key = os.getenv("TAVILY_API_KEY")
+    nvidia_api_key = os.getenv("NVIDIA_API_KEY") or settings.nvidia_api_key
+    tavily_api_key = os.getenv("TAVILY_API_KEY") or settings.tavily_api_key
 
-    if not openrouter_api_key or not tavily_api_key:
-        error_msg = "Missing API Keys. Please configure OPENROUTER_API_KEY and TAVILY_API_KEY"
+    if not nvidia_api_key or not tavily_api_key:
+        error_msg = "Missing API Keys. Please configure NVIDIA_API_KEY and TAVILY_API_KEY"
         logger.error(f"[{run_id}][{note_id}] {error_msg}")
 
         state["flags"].append(
@@ -43,13 +43,13 @@ def company_agent_node(state: AgentState) -> AgentState:
         )
         state["company_events"] = []
         return state
-    
+
     now = datetime.now(timezone.utc)
     month_name = MONTHS_PT[now.month]
     year_str = str(now.year)
 
     search_query = (
-        f"ticker {ticker} fatos relevantes CVM notícias"
+        f"ticker {ticker} fatos relevantes CVM notícias "
         f"InfoMoney Valor Econômico {month_name} {year_str}"
     )
 
@@ -76,10 +76,10 @@ def company_agent_node(state: AgentState) -> AgentState:
         )
         state["company_events"] = []
         return state
-    
+
     try:
         prompt_service = PromptManagementService()
-        
+
         system_template = prompt_service.load_prompt("company_agent_system")
         user_template = prompt_service.load_prompt("company_agent_user")
 
@@ -108,16 +108,12 @@ def company_agent_node(state: AgentState) -> AgentState:
         )
         state["company_events"] = []
         return state
-    
+
     try:
-        logger.info(f"[{run_id}][{note_id}] Requesting structured output from OpenRouter...")
+        logger.info(f"[{run_id}][{note_id}] Requesting structured output from NVIDIA...")
 
-        client = OpenAI(
-            api_key=openrouter_api_key,
-            base_url="https://openrouter.ai/api/v1"
-        )
-
-        target_model = "openrouter/free"
+        client = get_llm_client()
+        target_model = os.getenv("NVIDIA_MODEL", settings.nvidia_model)
 
         response = client.chat.completions.create(
             model=target_model,
@@ -152,7 +148,7 @@ def company_agent_node(state: AgentState) -> AgentState:
         logger.info(f"[{run_id}][{note_id}] CompanyAgent successfully completed analysis.")
 
     except Exception as model_err:
-        fail_msg = f"OpenRouter generation, parsing, or validation failed: {str(model_err)}"
+        fail_msg = f"NVIDIA generation, parsing, or validation failed: {str(model_err)}"
         logger.error(f"[{run_id}][{note_id}] {fail_msg}")
 
         state["flags"].append(

--- a/finagent/app/agents/editor.py
+++ b/finagent/app/agents/editor.py
@@ -1,14 +1,13 @@
-import os
 import logging
+import os
 import re
 import json
 from datetime import datetime, timezone
 
-from openai import OpenAI
-
+from app.core.config import get_llm_client, settings
 from app.graph.state import AgentState, Recommendation, EditorOutputSchema
-from app.utils.data_preprocessing import DataFlag
 from app.prompts.services.prompt_loader import PromptManagementService
+from app.utils.data_preprocessing import DataFlag
 
 logger = logging.getLogger("finagent.agents.editor")
 
@@ -19,10 +18,10 @@ def editor_agent_node(state: AgentState) -> AgentState:
 
     logger.info(f"[{run_id}][{note_id}] Starting EditorAgent compilation for {ticker}...")
 
-    openrouter_api_key = os.getenv("OPENROUTER_API_KEY")
+    nvidia_api_key = os.getenv("NVIDIA_API_KEY") or settings.nvidia_api_key
 
-    if not openrouter_api_key:
-        error_msg = "Missing API Key. Please configure OPENROUTER_API_KEY"
+    if not nvidia_api_key:
+        error_msg = "Missing API Key. Please configure NVIDIA_API_KEY"
         logger.error(f"[{run_id}][{note_id}] {error_msg}")
 
         state["flags"].append(
@@ -98,15 +97,13 @@ def editor_agent_node(state: AgentState) -> AgentState:
         return state
     
     try:
-        logger.info(f"[{run_id}][{note_id}] Requesting consolidated morning note from OpenRouter...")
+        logger.info(f"[{run_id}][{note_id}] Requesting consolidated morning note from NVIDIA...")
 
-        client = OpenAI(
-            api_key=openrouter_api_key,
-            base_url="https://openrouter.ai/api/v1"
-        )
+        client = get_llm_client()
+        target_model = os.getenv("NVIDIA_MODEL", settings.nvidia_model)
 
         response = client.chat.completions.create(
-            model="openrouter/free",
+            model=target_model,
             messages=[
                 {"role": "system", "content": system_prompt},
                 {"role": "user", "content": user_prompt}
@@ -143,7 +140,7 @@ def editor_agent_node(state: AgentState) -> AgentState:
         logger.info(f"[{run_id}][{note_id}] EditorAgent successfully compiled the investment morning note.")
 
     except Exception as model_err:
-        fail_msg = f"OpenRouter validation or distillation failed: {str(model_err)}"
+        fail_msg = f"NVIDIA validation or distillation failed: {str(model_err)}"
         logger.error(f"[{run_id}][{note_id}] {fail_msg}")
 
         state["flags"].append(

--- a/finagent/app/agents/macro.py
+++ b/finagent/app/agents/macro.py
@@ -1,14 +1,14 @@
-import os
 import logging
+import os
 import re
 from datetime import datetime, timezone
 
-from openai import OpenAI
 from tavily import TavilyClient
 
+from app.core.config import get_llm_client, settings
 from app.graph.state import AgentState, MacroOutput
-from app.utils.data_preprocessing import DataFlag
 from app.prompts.services.prompt_loader import PromptManagementService
+from app.utils.data_preprocessing import DataFlag
 
 MONTHS_PT = {
     1: "janeiro", 2: "fevereiro", 3: "março", 4: "abril",
@@ -19,23 +19,16 @@ MONTHS_PT = {
 logger = logging.getLogger("finagent.agents.macro")
 
 def macro_agent_node(state: AgentState) -> AgentState:
-    """
-    MacroAgent Node:
-    1. Gathers live Brazilian economic context using the Tavily Search API.
-    2. Synthesizes and extracts GDP, Inflation, and Interest Rates using OpenRouter (Llama 3.3 70B).
-    3. Guarantees structured JSON output mapping to our Pydantic MacroOutput schema.
-    4. Records execution metadata and handles external API failures gracefully.
-    """
     run_id = state.get("pipeline_run_id", "UNKNOWN_RUN")
     note_id = state.get("morning_note_id", "UNKNOWN_NOTE")
 
     logger.info(f"[{run_id}][{note_id}] Starting MacroAgent analysis.")
 
-    openrouter_api_key = os.getenv("OPENROUTER_API_KEY")
-    tavily_api_key = os.getenv("TAVILY_API_KEY")
+    nvidia_api_key = os.getenv("NVIDIA_API_KEY") or settings.nvidia_api_key
+    tavily_api_key = os.getenv("TAVILY_API_KEY") or settings.tavily_api_key
 
-    if not openrouter_api_key or not tavily_api_key:
-        error_msg = "Missing API Keys. Please configure OPENROUTER_API_KEY and TAVILY_API_KEY"
+    if not nvidia_api_key or not tavily_api_key:
+        error_msg = "Missing API Keys. Please configure NVIDIA_API_KEY and TAVILY_API_KEY"
         logger.error(f"[{run_id}][{note_id}] {error_msg}")
 
         state["flags"].append(
@@ -48,7 +41,7 @@ def macro_agent_node(state: AgentState) -> AgentState:
         )
         state["macro_context"] = None
         return state
-    
+
     now = datetime.now(timezone.utc)
     month_name = MONTHS_PT[now.month]
     year_str = str(now.year)
@@ -100,16 +93,12 @@ def macro_agent_node(state: AgentState) -> AgentState:
         )
         state["macro_context"] = None
         return state
-    
-    try:
-        logger.info(f"[{run_id}][{note_id}] Requesting structured output from OpenRouter...")
-        
-        client = OpenAI(
-            api_key=openrouter_api_key,
-            base_url="https://openrouter.ai/api/v1"
-        )
 
-        target_model = "openrouter/free"
+    try:
+        logger.info(f"[{run_id}][{note_id}] Requesting structured output from NVIDIA...")
+
+        client = get_llm_client()
+        target_model = os.getenv("NVIDIA_MODEL", settings.nvidia_model)
 
         schema_instruction = (
             f"You must return a valid JSON object matching this schema: "
@@ -128,14 +117,14 @@ def macro_agent_node(state: AgentState) -> AgentState:
             temperature=0.1
         )
 
-        raw_content = response.choices[0].message.content.strip()        
+        raw_content = response.choices[0].message.content.strip()
 
         cleaned_content = raw_content
         if cleaned_content.startswith("```"):
             cleaned_content = re.sub(r"^```(?:json)?\n", "", cleaned_content, flags=re.IGNORECASE)
             cleaned_content = re.sub(r"\n```$", "", cleaned_content)
             cleaned_content = cleaned_content.strip()
-        
+
         macro_data = MacroOutput.model_validate_json(cleaned_content)
         state["macro_context"] = macro_data
 
@@ -146,7 +135,7 @@ def macro_agent_node(state: AgentState) -> AgentState:
         logger.info(f"[{run_id}][{note_id}] MacroAgent successfully completed analysis.")
 
     except Exception as model_err:
-        fail_msg = f"OpenRouter generation or validation failed: {str(model_err)}"
+        fail_msg = f"NVIDIA generation or validation failed: {str(model_err)}"
         logger.error(f"[{run_id}][{note_id}] {fail_msg}")
 
         state["flags"].append(

--- a/finagent/app/agents/quant.py
+++ b/finagent/app/agents/quant.py
@@ -1,12 +1,12 @@
-import os
 import logging
+import os
 from datetime import datetime, timezone, timedelta
 import yfinance as yf
-from openai import OpenAI
 
-from app.graph.state import AgentState, QuantOutput 
-from app.utils.data_preprocessing import DataFlag
+from app.core.config import get_llm_client, settings
+from app.graph.state import AgentState, QuantOutput
 from app.prompts.services.prompt_loader import PromptManagementService
+from app.utils.data_preprocessing import DataFlag
 
 logger = logging.getLogger("finagent.agents.quant")
 
@@ -82,8 +82,8 @@ def quant_agent_node(state: AgentState) -> AgentState:
         )
         return state
 
-    openrouter_key = os.getenv("OPENROUTER_API_KEY")
-    if not openrouter_key:
+    nvidia_api_key = os.getenv("NVIDIA_API_KEY") or settings.nvidia_api_key
+    if not nvidia_api_key:
         logger.warning(f"[{run_id}][{note_id}][QuantAgent] Missing API Key. Storing raw metrics without analysis.")
         state["quant_metrics"] = QuantOutput(
             pe_ratio=pe_ratio,
@@ -108,9 +108,10 @@ def quant_agent_node(state: AgentState) -> AgentState:
             ibov_variance_30d="N/A"
         )
 
-        client = OpenAI(api_key=openrouter_key, base_url="https://openrouter.ai/api/v1")
+        client = get_llm_client()
+        target_model = os.getenv("NVIDIA_MODEL", settings.nvidia_model)
         response = client.chat.completions.create(
-            model="openrouter/free",
+            model=target_model,
             messages=[
                 {"role": "system", "content": formatted_system},
                 {"role": "user", "content": formatted_user}

--- a/finagent/app/agents/risk.py
+++ b/finagent/app/agents/risk.py
@@ -1,14 +1,13 @@
-import os
 import logging
+import os
 import re
 import json
 from datetime import datetime, timezone
 
-from openai import OpenAI
-
+from app.core.config import get_llm_client, settings
 from app.graph.state import AgentState, RiskFlag
-from app.utils.data_preprocessing import DataFlag
 from app.prompts.services.prompt_loader import PromptManagementService
+from app.utils.data_preprocessing import DataFlag
 
 logger = logging.getLogger("finagent.agents.risk")
 
@@ -19,10 +18,10 @@ def risk_agent_node(state: AgentState) -> AgentState:
 
     logger.info(f"[{run_id}][{note_id}] Starting RiskAgent analysis for {ticker}.")
 
-    openrouter_api_key = os.getenv("OPENROUTER_API_KEY")
+    nvidia_api_key = os.getenv("NVIDIA_API_KEY") or settings.nvidia_api_key
 
-    if not openrouter_api_key:
-        error_msg = "Missing API Key. Please configure OPENROUTER_API_KEY"
+    if not nvidia_api_key:
+        error_msg = "Missing API Key. Please configure NVIDIA_API_KEY"
         logger.error(f"[{run_id}][{note_id}] {error_msg}")
 
         state["flags"].append(
@@ -89,14 +88,10 @@ def risk_agent_node(state: AgentState) -> AgentState:
         return state
 
     try:
-        logger.info(f"[{run_id}][{note_id}] Requesting structured adversarial output from OpenRouter via gpt-4o...")
+        logger.info(f"[{run_id}][{note_id}] Requesting structured adversarial output from NVIDIA...")
 
-        client = OpenAI(
-            api_key=openrouter_api_key,
-            base_url="https://openrouter.ai/api/v1"
-        )
-
-        target_model = "openrouter/free"
+        client = get_llm_client()
+        target_model = os.getenv("NVIDIA_MODEL", settings.nvidia_model)
 
         response = client.chat.completions.create(
             model=target_model,
@@ -131,7 +126,7 @@ def risk_agent_node(state: AgentState) -> AgentState:
         logger.info(f"[{run_id}][{note_id}] RiskAgent successfully completed adversarial analysis loop.")
 
     except Exception as model_err:
-        fail_msg = f"OpenRouter generation, parsing, or validation failed: {str(model_err)}"
+        fail_msg = f"NVIDIA generation, parsing, or validation failed: {str(model_err)}"
         logger.error(f"[{run_id}][{note_id}] {fail_msg}")
 
         state["flags"].append(

--- a/finagent/app/core/config.py
+++ b/finagent/app/core/config.py
@@ -1,7 +1,84 @@
-from pydantic_settings import BaseSettings
+import os
+from typing import Optional
+
+from openai import OpenAI
+from openai import NotFoundError
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
 
 class Settings(BaseSettings):
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+        extra="ignore",
+        case_sensitive=False,
+    )
+
     app_name: str = "FinAgent"
-    enviroment: str = "development"
+    environment: str = "development"
+
+    nvidia_api_key: Optional[str] = None
+    nvidia_base_url: str = "https://integrate.api.nvidia.com/v1"
+    nvidia_model: str = "openai/gpt-oss-120b"
+    nvidia_fallback_model: str = "meta/llama-3.1-70b-instruct"
+
+    tavily_api_key: Optional[str] = None
+
 
 settings = Settings()
+
+
+class _FallbackCompletions:
+    """Mimics `client.chat.completions` and transparently retries with the
+    fallback NVIDIA model when the primary is not provisioned for the account.
+    """
+
+    def __init__(self, client: OpenAI, primary: str, fallback: Optional[str]):
+        self._client = client
+        self._primary = primary
+        self._fallback = fallback
+        self.create = self._create
+
+    def _create(self, *, model: Optional[str] = None, **kwargs):
+        candidates = [model or self._primary]
+        if self._fallback and self._fallback not in candidates:
+            candidates.append(self._fallback)
+
+        last_error: Optional[Exception] = None
+        for candidate in candidates:
+            try:
+                return self._client.chat.completions.create(model=candidate, **kwargs)
+            except NotFoundError as exc:
+                last_error = exc
+                continue
+
+        assert last_error is not None
+        raise last_error
+
+
+class FallbackLLMClient:
+    """Drop-in replacement for the OpenAI client exposing the same
+    `chat.completions.create(model=..., **kwargs)` surface used by agents.
+    """
+
+    def __init__(self, client: OpenAI, primary: str, fallback: Optional[str] = None):
+        self._client = client
+        self.chat = type(
+            "Chat", (), {"completions": _FallbackCompletions(client, primary, fallback)}
+        )()
+
+
+def get_llm_client():
+    if not settings.nvidia_api_key:
+        raise ValueError(
+            "NVIDIA_API_KEY is not configured. Set it in .env or as an environment variable."
+        )
+    env_model = os.getenv("NVIDIA_MODEL")
+    primary = env_model or settings.nvidia_model
+    fallback = os.getenv("NVIDIA_FALLBACK_MODEL") or settings.nvidia_fallback_model
+    client = OpenAI(
+        api_key=settings.nvidia_api_key,
+        base_url=settings.nvidia_base_url,
+        timeout=60.0,
+    )
+    return FallbackLLMClient(client, primary=primary, fallback=fallback or None)

--- a/finagent/app/graph/pipeline.py
+++ b/finagent/app/graph/pipeline.py
@@ -1,0 +1,118 @@
+import os
+from datetime import datetime, timezone
+from typing import Any, Dict
+
+from langgraph.checkpoint.postgres import PostgresSaver
+from langgraph.graph import END, START, StateGraph
+from psycopg_pool import ConnectionPool
+
+from app.agents.company import company_agent_node
+from app.agents.editor import editor_agent_node
+from app.agents.macro import macro_agent_node
+from app.agents.quant import quant_agent_node
+from app.agents.risk import risk_agent_node
+from app.graph.state import AgentState
+
+# 1. Fetch environment connection target
+raw_conn_string = os.getenv(
+    "DATABASE_URL",
+    "postgresql://finagent:finagent_secure_pass@localhost:5432/finagent",
+)
+
+# 2. Format connection string for compatibility
+clean_uri = raw_conn_string.replace("postgresql+asyncpg://", "postgresql://")
+
+try:
+    prefix_and_creds, remaining = clean_uri.split("@")
+    host_and_port = remaining.split("/")[0]
+    host_address = host_and_port.split(":")[0]
+    DB_CONN_STRING = f"{prefix_and_creds}@{host_address}:5433/finagent_graph"
+except Exception:
+    DB_CONN_STRING = "postgresql://finagent:finagent_secure_pass@localhost:5433/finagent_graph"
+
+# 3. Configure ConnectionPool with autocommit enabled
+# This allows DDL schemas and concurrent index structures to deploy safely
+import atexit as _atexit
+
+pool = ConnectionPool(
+    conninfo=DB_CONN_STRING,
+    max_size=10,
+    min_size=2,
+    timeout=5.0,
+    kwargs={"autocommit": True},  # <-- Add this right here!
+    open=False,
+)
+pool.open(wait=True, timeout=5.0)
+
+
+def _shutdown_pool():
+    try:
+        pool.close()
+    except Exception:
+        pass
+
+
+_atexit.register(_shutdown_pool)
+
+
+def create_financial_agent_graph():
+    """Builds the 5-node StateGraph: macro/company/quant fan-into risk, then editor."""
+    graph = StateGraph(AgentState)
+    graph.add_node("macro", macro_agent_node)
+    graph.add_node("company", company_agent_node)
+    graph.add_node("quant", quant_agent_node)
+    graph.add_node("risk", risk_agent_node)
+    graph.add_node("editor", editor_agent_node)
+
+    graph.add_edge(START, "macro")
+    graph.add_edge(START, "company")
+    graph.add_edge(START, "quant")
+    graph.add_edge("macro", "risk")
+    graph.add_edge("company", "risk")
+    graph.add_edge("quant", "risk")
+    graph.add_edge("risk", "editor")
+    graph.add_edge("editor", END)
+
+    return graph.compile()
+
+
+def run_financial_pipeline(initial_state: AgentState) -> Dict[str, Any]:
+    """
+    Executes the multi-agent StateGraph with structural Postgres checkpointing
+    and passes operational business metadata tags directly down to LangSmith.
+    """
+    print("[*] Connecting to Postgres Graph Database on Port 5433...")
+    checkpointer = PostgresSaver(pool)
+    checkpointer.setup()
+    print("[OK] Database Checkpointer ready.")
+
+    print("[*] Initializing Agent Graph Topology...")
+    graph = create_financial_agent_graph()
+
+    manager_id = initial_state.get("manager_id")
+    company = initial_state.get("company_ticker")
+    pipeline_run_id = initial_state.get("pipeline_run_id")
+    morning_note_id = initial_state.get("morning_note_id")
+    date_stamp = datetime.now(timezone.utc).date().isoformat()
+
+    config = {
+        "configurable": {
+            "thread_id": f"{pipeline_run_id}_{company}",
+            "recursion_limit": 15,
+        },
+        "metadata": {
+            "manager_id": manager_id,
+            "company": company,
+            "date": date_stamp,
+            "pipeline_run_id": pipeline_run_id,
+            "morning_note_id": morning_note_id,
+        },
+        "tags": [f"manager:{manager_id}", f"ticker:{company}", f"run:{pipeline_run_id}"],
+    }
+
+    print(f"[START] Invoking LangGraph runtime thread: {pipeline_run_id}_{company}...")
+    graph.checkpointer = checkpointer
+    final_state = graph.invoke(initial_state, config=config)
+
+    _shutdown_pool()
+    return final_state

--- a/finagent/app/graph/state.py
+++ b/finagent/app/graph/state.py
@@ -1,9 +1,33 @@
 from datetime import datetime, timezone
-from typing import Dict, List, Optional, Any, TypedDict
+from typing import Dict, List, Optional, Any, Annotated
+from typing_extensions import TypedDict
 from pydantic import BaseModel, Field
 from app.utils.data_preprocessing import DataFlag
 
-# 1. Helper Output Models (Schemas)
+
+# ======================================================================
+# 1. State Merging Reducers (Required for Parallel Execution)
+# ======================================================================
+
+def _keep_last(left: Any, right: Any) -> Any:
+    """Last-write-wins reducer for immutable correlation fields that every
+    parallel agent echoes back unchanged. Without this reducer LangGraph
+    raises INVALID_CONCURRENT_GRAPH_UPDATE when more than one node writes
+    the same scalar key in a single superstep."""
+    return right if right is not None else left
+
+
+def _merge_lists(left: List[Any], right: List[Any]) -> List[Any]:
+    return (left or []) + (right or [])
+
+
+def _merge_dicts(left: Dict[str, Any], right: Dict[str, Any]) -> Dict[str, Any]:
+    return {**(left or {}), **(right or {})}
+
+
+# ======================================================================
+# 2. Helper Output Models (Schemas)
+# ======================================================================
 
 class MacroOutput(BaseModel):
     """Structured macroeconomic indicators and contextual insights"""
@@ -54,22 +78,24 @@ class EditorOutputSchema(BaseModel):
 
 class AgentState(TypedDict):
     """Main state carried throughout the LangGraph milti-agent execution pipeline"""
-    pipeline_run_id: str
-    morning_note_id: str
-    manager_id: int
-    company_ticker: str
+    # Correlation fields must be last-write-wins because parallel agents echo
+    # them back unchanged on every superstep.
+    pipeline_run_id: Annotated[str, _keep_last]
+    morning_note_id: Annotated[str, _keep_last]
+    manager_id: Annotated[int, _keep_last]
+    company_ticker: Annotated[str, _keep_last]
 
     macro_context: Optional[MacroOutput]
-    company_events: List[CompanyEvent]
+    company_events: Annotated[List[CompanyEvent], _merge_lists]
     quant_metrics: Optional[QuantOutput]
-    risk_flags: List[RiskFlag]
+    risk_flags: Annotated[List[RiskFlag], _merge_lists]
 
     morning_note: Optional[str]
     recommendation: Optional[Recommendation]
 
-    confidence_scores: Dict[str, float]
-    data_freshness: Dict[str, datetime]
-    flags: List[DataFlag]
+    confidence_scores: Annotated[Dict[str, float], _merge_dicts]
+    data_freshness: Annotated[Dict[str, Any], _merge_dicts]
+    flags: Annotated[List[DataFlag], _merge_lists]
 
 # 3. State Operations & Invariants
 

--- a/finagent/tests/integration/test_pipeline.py
+++ b/finagent/tests/integration/test_pipeline.py
@@ -1,0 +1,88 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from datetime import datetime, timezone
+from langgraph.graph.state import CompiledStateGraph
+
+from app.graph.state import create_initial_state, Recommendation
+from app.graph.pipeline import run_financial_pipeline
+
+@pytest.fixture
+def mock_db_and_graph():
+    """Mocks the database connection pool and structural agent node logic."""
+    with patch("app.graph.pipeline.ConnectionPool") as mock_pool, \
+         patch("app.graph.pipeline.PostgresSaver") as mock_saver, \
+         patch("app.graph.pipeline.macro_agent_node") as mock_macro, \
+         patch("app.graph.pipeline.company_agent_node") as mock_company, \
+         patch("app.graph.pipeline.quant_agent_node") as mock_quant, \
+         patch("app.graph.pipeline.risk_agent_node") as mock_risk, \
+         patch("app.graph.pipeline.editor_agent_node") as mock_editor:
+        
+        # Mock agent return values (sparse dicts to prevent concurrent write collisions)
+        mock_macro.return_value = {"macro_context": MagicMock()}
+        mock_company.return_value = {"company_events": [MagicMock()]}
+        mock_quant.return_value = {"quant_metrics": MagicMock()}
+        mock_risk.return_value = {"risk_flags": []}
+        
+        def editor_effect(state):
+            state["morning_note"] = "### Executive Summary\nStrong fundamentals verified."
+            state["recommendation"] = Recommendation(
+                action="BUY",
+                target_weight=15.0,
+                horizon_months=12,
+                thesis_summary="Test thesis pass."
+            )
+            return state
+        mock_editor.side_effect = editor_effect
+        
+        yield {
+            "pool": mock_pool,
+            "saver": mock_saver,
+            "editor": mock_editor
+        }
+
+def test_pipeline_attaches_checkpointing_and_metadata_tags(mock_db_and_graph):
+    """
+    TDD Test: Verifies that the production runner configures the Postgres checkpointer 
+    and passes the structural LangSmith tracking metadata required by Issue #14.
+    """
+    initial_state = create_initial_state(
+        pipeline_run_id="run-tdd-123",
+        morning_note_id="note-tdd-456",
+        manager_id=42,
+        company_ticker="PETR4"
+    )
+    initial_state["data_freshness"]["company"] = datetime.now(timezone.utc).isoformat()
+    
+    # We spy on CompiledStateGraph.invoke to inspect what configuration arguments are injected
+    with patch.object(CompiledStateGraph, "invoke", autospec=True) as spy_invoke:
+        spy_invoke.return_value = {
+            **initial_state,
+            "morning_note": "Mocked Note",
+            "recommendation": Recommendation(action="BUY", target_weight=10.0, thesis_summary="...")
+        }
+        
+        # Execute the wrapper under test
+        run_financial_pipeline(initial_state)
+        
+        # 1. Verify checkpointer initialization was commanded
+        mock_db_and_graph["saver"].return_value.setup.assert_called_once()
+        
+        # 2. Extract configuration payload delivered to the LangGraph execution runtime
+        assert spy_invoke.call_count == 1
+        called_args, called_kwargs = spy_invoke.call_args
+        
+        config = called_kwargs.get("config", {})
+        metadata = config.get("metadata", {})
+        tags = config.get("tags", [])
+        
+        # 3. Enforce precise LangSmith tracking specifications (Issue #14)
+        assert metadata["manager_id"] == 42
+        assert metadata["company"] == "PETR4"
+        assert metadata["pipeline_run_id"] == "run-tdd-123"
+        assert metadata["morning_note_id"] == "note-tdd-456"
+        assert "date" in metadata
+        
+        assert "manager:42" in tags
+        assert "ticker:PETR4" in tags
+        assert "thread_id" in config.get("configurable", {})
+


### PR DESCRIPTION
## Summary
Migrate the multi-agent FinAgent pipeline from OpenRouter to NVIDIA NIM, introduce a parallel LangGraph topology with Postgres-backed structural checkpointing, and pin the agent state with parallel-safe reducers.

## Motivation
- OpenRouter's free tier became unreliable for the structured JSON contracts required by our Pydantic schemas (MacroOutput, QuantOutput, RiskFlag, Recommendation).
- NVIDIA's integrate.api.nvidia.com provides a stable OpenAI-compatible surface with free trial-tier access to open-weight models.
- The agents already run in parallel inside our internal scripts, but the production runner was missing the LangGraph topology, Postgres checkpointing, and LangSmith tagging contract (Issue #14).

## Changes
- **chore(config)** — `db1308c`
  - Replace bare `BaseSettings` with full `SettingsConfigDict` (.env, utf-8, case-insensitive).
  - Fix `enviroment` typo → `environment`.
  - Add NVIDIA key/base_url/model/fallback_model + Tavily fields.
  - Add `FallbackLLMClient` with `_FallbackCompletions`: retries with the fallback model when the primary NIM returns `NotFoundError` (private NIM not provisioned for the account), preserving `client.chat.completions.create(model=..., **kwargs)`.
  - Add `finagent/.env.example` documenting the local setup.

- **feat(graph)** — `dc86534`
  - Annotate `AgentState` fields with `Annotated[..., reducer]` so LangGraph supersteps that fan macro/company/quant in parallel do not raise `INVALID_CONCURRENT_GRAPH_UPDATE`.
  - `_keep_last`: correlation scalars (pipeline_run_id, morning_note_id, manager_id, company_ticker).
  - `_merge_lists`: append-only collections (company_events, risk_flags, flags).
  - `_merge_dicts`: per-key unions for confidence_scores / data_freshness.
  - Switch `TypedDict` import to `typing_extensions` for Python 3.10.

- **feat(agents)** — `2fe184e`
  - Migrate macro/company/quant/risk/editor from OpenRouter to `get_llm_client()`.
  - Replace `OPENROUTER_API_KEY` checks with `NVIDIA_API_KEY` (env-overridable).
  - Drop inline `OpenAI(base_url='https://openrouter.ai/api/v1')` construction.
  - Update error messages from “OpenRouter generation failed” → “NVIDIA generation failed”.

- **feat(pipeline)** — `b2d40bd`
  - `app/graph/pipeline.py`: `create_financial_agent_graph` wires macro/company/quant as a START fan-out, merges into risk, then editor → END.
  - `ConnectionPool + PostgresSaver` with autocommit-safe configuration on the `finagent_graph` Postgres database (port 5433); `atexit` hook releases the pool.
  - `run_financial_pipeline` injects LangSmith tracking tags + metadata (manager_id, company, pipeline_run_id, morning_note_id, date) and a stable `thread_id` per run/ticker.
  - `agents_scripts/run_pipeline.py`: standalone launcher with UTF-8 stdout, env validation, and deduplicated flag report.
  - Clean emoji glyphs from `run_live_editor.py` (Windows cp1252 crash fix).

- **test(pipeline)** — `e35e479`
  - TDD integration test verifying PostgresSaver setup, LangSmith metadata, tags, and configurable.thread_id.
  - Fix mock patch target from legacy `app.graph.builder` to `app.graph.pipeline`.

## Test plan
- [x] `pytest finagent/tests/integration/test_pipeline.py -v` passes with the mocked DB pool.
- [ ] Manual smoke: `python finagent/agents_scripts/run_pipeline.py` against PETR4 with valid `NVIDIA_API_KEY` + `TAVILY_API_KEY`.
- [ ] Verify LangSmith traces show `manager:*`, `ticker:PETR4`, `run:*` tags and the full metadata payload.

## Breaking changes
- `OPENROUTER_API_KEY` is no longer read; `NVIDIA_API_KEY` is required.
- `DATA_FRESHNESS` values are now typed as `Any` (mixed ISO strings + datetimes); consumers should normalize with `datetime.fromisoformat`.

## Related
- Closes the OpenRouter migration track alongside `chore/migrate-to-openai-sdk`.
