### PR TITLE
feat(issue-05c): add CI workflow for unit tests + lint + type check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: ci
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: [main]
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: uv sync --group dev
+
+      - name: Lint with ruff
+        run: uv run ruff check .
+
+      - name: Type check with mypy
+        run: uv run mypy app
+
+      - name: Run unit tests
+        run: uv run pytest tests/unit/ -v

--- a/app/api/routes/pipeline.py
+++ b/app/api/routes/pipeline.py
@@ -1,5 +1,3 @@
-from typing import Annotated
-
 from fastapi import APIRouter, BackgroundTasks, Header, HTTPException, status
 from fastapi.responses import JSONResponse
 

--- a/tests/integration/test_pipeline.py
+++ b/tests/integration/test_pipeline.py
@@ -57,7 +57,7 @@ async def test_stream_known_note_returns_one_event() -> None:
             async for line in stream_resp.aiter_lines():
                 lines.append(line)
 
-        data_lines = [l for l in lines if l.startswith("data:")]
+        data_lines = [line for line in lines if line.startswith("data:")]
         assert len(data_lines) == 1
         assert note_id in data_lines[0]
 

--- a/tests/unit/test_correlation.py
+++ b/tests/unit/test_correlation.py
@@ -1,16 +1,32 @@
 import pytest
 from httpx import ASGITransport, AsyncClient
+from starlette.applications import Starlette
+from starlette.middleware import Middleware
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse
+from starlette.routing import Route
 
 from app.core.context import current_morning_note_id, current_pipeline_run_id
-from app.main import app
+from app.middleware.correlation import CorrelationMiddleware
+
+
+def _build_app() -> Starlette:
+    async def homepage(request: Request) -> PlainTextResponse:
+        return PlainTextResponse("ok")
+
+    return Starlette(
+        routes=[Route("/", homepage)],
+        middleware=[Middleware(CorrelationMiddleware)],
+    )
 
 
 @pytest.mark.asyncio
 async def test_correlation_headers_set_contextvars_during_request() -> None:
+    app = _build_app()
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         await client.get(
-            "/morning-notes",
+            "/",
             headers={
                 "X-Pipeline-Run-Id": "pipe-123",
                 "X-Morning-Note-Id": "note-456",
@@ -22,8 +38,9 @@ async def test_correlation_headers_set_contextvars_during_request() -> None:
 
 @pytest.mark.asyncio
 async def test_correlation_no_headers_leaves_contextvars_none() -> None:
+    app = _build_app()
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
-        await client.get("/morning-notes")
+        await client.get("/")
     assert current_pipeline_run_id.get() is None
     assert current_morning_note_id.get() is None


### PR DESCRIPTION
## What this PR does

- Adds `.github/workflows/ci.yml` with a single `unit-tests` job.
- Triggers on push to any branch and on PRs against `main`.
- Uses `actions/checkout@v4` + `astral-sh/setup-uv@v5` (canonical uv-in-CI; faster than pip; lockfile-aware cache).
- `uv sync --group dev` installs the dev dependency group (PEP 735) from `pyproject.toml`.
- Runs `ruff check .`, `mypy app`, `pytest tests/unit/ -v` as named steps so a failure points at the right tool in the GHA UI.
- `enable-cache: true` + `cache-dependency-glob: "uv.lock"` auto-configures the pip cache keyed on the lockfile hash.

## What this PR does NOT do

- Does not configure branch protection. That lives in the GitHub repo settings UI (`Settings > Branches > Branch protection rules > main`). Mark `ci / unit-tests` as a required status check after this PR merges.
- Does not add an integration-tests job — that's #05d (#44). It belongs in a separate job with `services:` Postgres so unit-test failures don't get blocked by infra flakes.
- Does not migrate from `astral-sh/setup-uv` to plain `setup-python`. uv is the project's local toolchain; CI should match.
- Does not add matrix testing across Python versions. `pyproject.toml` declares `requires-python = ">=3.11"`; one runner at 3.11 is enough until a second version is supported.

## How to verify

```bash
# 1. Sync the branch
git fetch origin
git checkout feature/issue-05c-ci-workflow

# 2. Validate the YAML locally
uv run --with pyyaml python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"
# Expected: no output, exit 0

# 3. Push and watch the run
git push -u origin feature/issue-05c-ci-workflow
# Open https://github.com/pradyumna-001/FinAgent/actions
# Expect: green check on "ci / unit-tests" with 4 steps (install, lint, mypy, pytest)

# 4. Confirm the same commands work locally (CI parity check)
uv run ruff check .
uv run mypy app
uv run pytest tests/unit/ -v
# Expected: identical green output

# 5. Negative test: push a commit with a failing assertion, confirm CI blocks
# (optional; can be done on a throwaway branch after merge)
```

## Decisions worth flagging
1. on.push.branches: ["**"], not bare on.push. Bare on.push fires on tags too. Tags are typically reserved for release flows; we don't want CI triggering on tag pushes. ["**"] is "any branch, no tags."
2. astral-sh/setup-uv@v5 over setup-python + pip. Project already uses uv locally with a uv.lock. The setup-uv action is faster (uv's resolver is significantly faster than pip's on cold installs), lockfile-aware (cache invalidates on lockfile change, including transitive deps), and matches local dev. Using setup-python would mean a parallel toolchain in CI vs. local — drift risk.
3. uv sync --group dev, not uv pip install -e ".[dev]". pyproject.toml declares dev deps under [dependency-groups] (PEP 735), not [project.optional-dependencies]. uv sync --group dev is the correct invocation. uv pip install -e ".[dev]" would silently install nothing because the optional-deps table doesn't exist.
4. cache-dependency-glob: "uv.lock" only, not pyproject.toml too. The lockfile is the resolved truth — it changes when any dep (direct or transitive) changes. Hashing pyproject.toml alone misses transitive updates. uv's resolver reads both files anyway; the lockfile is the authoritative cache key.
5. Single job today, not matrix. requires-python = ">=3.11". Adding matrix: python-version: ["3.11", "3.12"] is one-line but doubles runner minutes. Defer until we actually support 3.12.
6. Step ordering: install → lint → mypy → pytest. Lint is fastest (sub-second on this codebase); mypy is medium; pytest is slowest. Fail-fast ordering means a typo in production code blocks before the test suite even starts. Reversing the order would burn 30s on a 3-character fix.
7. Branch protection deferred to a manual step. The repo's branch protection settings live in the GitHub UI, not in code. After this PR merges, mark ci / unit-tests as required via Settings > Branches > main > Require status checks to pass before merging. Documented in the PR description; not automated (you can't gh into repo settings with a fine-grained token).