### PR TITLE
fix(tests): stub DATABASE_URL env vars at conftest import time

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,15 @@ import pytest
 from docker.errors import DockerException
 from testcontainers.community.postgres import PostgresContainer
 
+os.environ.setdefault(
+    "DATABASE_URL",
+    "postgresql+asyncpg://placeholder@localhost:5432/placeholder",
+)
+os.environ.setdefault(
+    "MIGRATION_DATABASE_URL",
+    "postgresql://placeholder@localhost:5432/placeholder",
+)
+
 
 @pytest.fixture(scope="session")
 def pg_container() -> Generator[PostgresContainer, None, None]:
@@ -19,7 +28,9 @@ def pg_container() -> Generator[PostgresContainer, None, None]:
         with PostgresContainer("pgvector/pgvector:pg16") as pg:
             yield pg
     except DockerException:
-        pytest.skip("Docker daemon not reachable. Start Docker Desktop or configure DOCKER_HOST.")
+        pytest.skip(
+            "Docker daemon not reachable. Start Docker Desktop or configure DOCKER_HOST."
+        )
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## What this PR does

- Adds `os.environ.setdefault(...)` for `DATABASE_URL` and `MIGRATION_DATABASE_URL` at the top of `tests/conftest.py`, before any test collection.

## What this PR does NOT do

- Does not change any test logic — only adds env stubs at conftest import time.
- Does not introduce a CI workflow job for integration tests — that's #05d (#44).
- Does not change the runtime fixtures (`migrated_db_url`, `rls_role`) — they still override `DATABASE_URL` at session scope when DB-backed tests run.

## How to verify

```bash
# 1. Sync the branch
git fetch origin
git checkout fix/integration-test-collection-env-stub

# 2. Simulate CI (no .env, no env vars)
env -u DATABASE_URL -u MIGRATION_DATABASE_URL uv run pytest tests/unit/ --collect-only
env -u DATABASE_URL -u MIGRATION_DATABASE_URL uv run pytest tests/integration/ --collect-only
# Expected: 8 unit tests + 12 integration tests collected, zero errors

# 3. Normal local run still works (devs with .env keep real URLs)
uv run pytest tests/unit/ -v
# Expected: 8 passed

# 4. Lint + format clean
uv run ruff check tests/conftest.py
uv run ruff format --check tests/conftest.py
# Expected: All checks passed, already formatted
```

## Decisions worth flagging
1. setdefault, not direct assignment. Local devs with a .env file keep their real DB URLs — setdefault only fills when the env var is absent. CI without .env gets harmless placeholders that satisfy Settings() validation but never get connected to.
2. Placeholders are syntactically valid but unreachable. postgresql+asyncpg://placeholder@localhost:5432/placeholder parses fine for pydantic, but tests that actually touch the DB override DATABASE_URL via the migrated_db_url fixture before any connection attempt. The placeholder is a collection-time band-aid, not a runtime URL.
3. Module-level, not fixture-scoped. Settings() is constructed at import time when app.main is imported. A fixture would run too late — collection would still fail before fixtures activate. Module-level setdefault runs first, before any from app.main import app.
4. Same pattern as test_correlation.py refactor, applied at a different layer. That refactor skipped the full app import entirely; this one keeps the import but stubs its env dependencies. Different fix because the tests are genuinely integration tests — they need the real app, not a synthetic one.
5. Follow-up: this fix unblocks #05d. With collection now working in CI, the integration-tests job can be added to .github/workflows/ci.yml without the smoke-failing-on-import problem.