### PR TITLE
feat(rls): Closes #31 — RLS on remaining five tables + WITH CHECK on isolation policies

### DIFF
--- a/alembic/versions/1700dce69c30_enable_rls_on_remaining_tables.py
+++ b/alembic/versions/1700dce69c30_enable_rls_on_remaining_tables.py
@@ -1,0 +1,97 @@
+"""enable RLS on managers, companies, portfolios, portfolio_holdings, recommendations
+
+Revision ID: 1700dce69c30
+Revises: 1d4e6f8a2b35
+Create Date: 2026-08-06 18:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "1700dce69c30"
+down_revision: Union[str, Sequence[str], None] = "1d4e6f8a2b35"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE managers ENABLE ROW LEVEL SECURITY")
+    op.execute(
+        "CREATE POLICY managers_all_visible "
+        "ON managers "
+        "FOR ALL "
+        "USING (true) "
+        "WITH CHECK (true)"
+    )
+
+    op.execute("ALTER TABLE companies ENABLE ROW LEVEL SECURITY")
+    op.execute(
+        "CREATE POLICY companies_all_visible "
+        "ON companies "
+        "FOR ALL "
+        "USING (true) "
+        "WITH CHECK (true)"
+    )
+
+    op.execute("ALTER TABLE portfolios ENABLE ROW LEVEL SECURITY")
+    op.execute(
+        "CREATE POLICY portfolios_manager_isolation "
+        "ON portfolios "
+        "USING (manager_id = current_setting('app.manager_id', true)::int) "
+        "WITH CHECK (manager_id = current_setting('app.manager_id', true)::int)"
+    )
+
+    op.execute("ALTER TABLE portfolio_holdings ENABLE ROW LEVEL SECURITY")
+    op.execute(
+        "CREATE POLICY portfolio_holdings_via_portfolio "
+        "ON portfolio_holdings "
+        "USING (EXISTS ("
+        "  SELECT 1 FROM portfolios p "
+        "  WHERE p.id = portfolio_holdings.portfolio_id "
+        "  AND p.manager_id = current_setting('app.manager_id', true)::int"
+        "))"
+        "WITH CHECK  (EXISTS ("
+                "  SELECT 1 FROM portfolios p "
+                "  WHERE p.id = portfolio_holdings.portfolio_id "
+                "  AND p.manager_id = current_setting('app.manager_id', true)::int"
+        "))"
+    )
+
+    op.execute("ALTER TABLE recommendations ENABLE ROW LEVEL SECURITY")
+    op.execute(
+        "CREATE POLICY recommendations_via_morning_note "
+        "ON recommendations "
+        "USING (EXISTS ("
+        "  SELECT 1 FROM morning_notes mn "
+        "  WHERE mn.id = recommendations.morning_note_id "
+        "  AND mn.manager_id = current_setting('app.manager_id', true)::int"
+        ")) "
+        "WITH CHECK (EXISTS ("
+                "  SELECT 1 FROM morning_notes mn "
+                "  WHERE mn.id = recommendations.morning_note_id "
+                "  AND mn.manager_id = current_setting('app.manager_id', true)::int"
+        "))"
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "DROP POLICY IF EXISTS recommendations_via_morning_note ON recommendations"
+    )
+    op.execute("ALTER TABLE recommendations DISABLE ROW LEVEL SECURITY")
+
+    op.execute(
+        "DROP POLICY IF EXISTS portfolio_holdings_via_portfolio ON portfolio_holdings"
+    )
+    op.execute("ALTER TABLE portfolio_holdings DISABLE ROW LEVEL SECURITY")
+
+    op.execute("DROP POLICY IF EXISTS portfolios_manager_isolation ON portfolios")
+    op.execute("ALTER TABLE portfolios DISABLE ROW LEVEL SECURITY")
+
+    op.execute("DROP POLICY IF EXISTS companies_all_visible ON companies")
+    op.execute("ALTER TABLE companies DISABLE ROW LEVEL SECURITY")
+
+    op.execute("DROP POLICY IF EXISTS managers_all_visible ON managers")
+    op.execute("ALTER TABLE managers DISABLE ROW LEVEL SECURITY")

--- a/alembic/versions/1d4e6f8a2b35_enable_rls_on_morning_notes_.py
+++ b/alembic/versions/1d4e6f8a2b35_enable_rls_on_morning_notes_.py
@@ -21,7 +21,8 @@ def upgrade() -> None:
     op.execute(
         "CREATE POLICY morning_notes_manager_isolation "
         "ON morning_notes "
-        "USING (manager_id = current_setting('app.manager_id', true)::int)"
+        "USING (manager_id = current_setting('app.manager_id', true)::int) "
+        "WITH CHECK (manager_id = current_setting('app.manager_id', true)::int)"
     )
 
 

--- a/alembic/versions/1d4e6f8a2b35_enable_rls_on_morning_notes_.py
+++ b/alembic/versions/1d4e6f8a2b35_enable_rls_on_morning_notes_.py
@@ -21,8 +21,7 @@ def upgrade() -> None:
     op.execute(
         "CREATE POLICY morning_notes_manager_isolation "
         "ON morning_notes "
-        "USING (manager_id = current_setting('app.manager_id', true)::int) "
-        "WITH CHECK (manager_id = current_setting('app.manager_id', true)::int)"
+        "USING (manager_id = current_setting('app.manager_id', true)::int)"
     )
 
 

--- a/alembic/versions/a74d884aeda7_add_with_check_to_morning_notes_isolation.py
+++ b/alembic/versions/a74d884aeda7_add_with_check_to_morning_notes_isolation.py
@@ -1,0 +1,30 @@
+"""add WITH CHECK to morning_notes_manager_isolation policy
+
+Revision ID: a74d884aeda7
+Revises: 1700dce69c30
+Create Date: 2026-08-07 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "a74d884aeda7"
+down_revision: Union[str, Sequence[str], None] = "1700dce69c30"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER POLICY morning_notes_manager_isolation ON morning_notes "
+        "WITH CHECK (manager_id = current_setting('app.manager_id', true)::int)"
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "ALTER POLICY morning_notes_manager_isolation ON morning_notes "
+        "USING (manager_id = current_setting('app.manager_id', true)::int)"
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,9 @@ def pg_container() -> Generator[PostgresContainer, None, None]:
         with PostgresContainer("pgvector/pgvector:pg16") as pg:
             yield pg
     except DockerException:
-        pytest.skip("Docker daemon not reachable. Start Docker Desktop or configure DOCKER_HOST.")
+        pytest.skip(
+            "Docker daemon not reachable. Start Docker Desktop or configure DOCKER_HOST."
+        )
 
 
 @pytest.fixture(scope="session")
@@ -48,31 +50,73 @@ def rls_role(migrated_db_url: str) -> Generator[str, None, None]:
     async def _setup() -> None:
         conn = await _admin()
         try:
-            await conn.execute(
-                "CREATE ROLE rls_test NOSUPERUSER NOBYPASSRLS "
-                "LOGIN PASSWORD 'rls_test_pwd'"
-            )
+            try:
+                await conn.execute(
+                    "CREATE ROLE rls_test NOSUPERUSER NOBYPASSRLS "
+                    "LOGIN PASSWORD 'rls_test_pwd'"
+                )
+            except asyncpg.exceptions.DuplicateObjectError:
+                pass
             await conn.execute("GRANT USAGE ON SCHEMA public TO rls_test")
             await conn.execute("GRANT SELECT ON morning_notes TO rls_test")
             await conn.execute(
                 "INSERT INTO managers (id, name, email) VALUES "
                 "(2, 'Alice', 'alice@example.com'), "
-                "(3, 'Bob', 'bob@example.com')"
+                "(3, 'Bob', 'bob@example.com') "
+                "ON CONFLICT (id) DO NOTHING"
             )
             await conn.execute(
                 "INSERT INTO companies (id, ticker, name) VALUES "
-                "(10, 'AAPL', 'Apple Inc')"
+                "(10, 'AAPL', 'Apple Inc') "
+                "ON CONFLICT (id) DO NOTHING"
             )
             await conn.execute(
                 "INSERT INTO portfolios (id, manager_id, name) VALUES "
-                "(100, 2, 'Alice growth'), (200, 3, 'Bob value')"
+                "(100, 2, 'Alice growth'), (200, 3, 'Bob value') "
+                "ON CONFLICT (id) DO NOTHING"
             )
             await conn.execute(
                 "INSERT INTO morning_notes "
-                "(portfolio_id, manager_id, company_id, note_text) VALUES "
+                "(portfolio_id, manager_id, company_id, note_text) "
+                "SELECT * FROM (VALUES "
                 "(100, 2, 10, 'note-a1'), (100, 2, 10, 'note-a2'), "
-                "(200, 3, 10, 'note-b1')"
+                "(200, 3, 10, 'note-b1') "
+                ") AS v(portfolio_id, manager_id, company_id, note_text) "
+                "WHERE NOT EXISTS ("
+                "SELECT 1 FROM morning_notes mn "
+                "WHERE mn.portfolio_id = v.portfolio_id "
+                "AND mn.note_text = v.note_text"
+                ")"
             )
+            await conn.execute(
+                "INSERT INTO portfolio_holdings (portfolio_id, company_id, weight) "
+                "SELECT * FROM (VALUES "
+                "(100, 10, 0.5), (200, 10, 1.0) "
+                ") AS v(portfolio_id, company_id, weight) "
+                "WHERE NOT EXISTS ("
+                "SELECT 1 FROM portfolio_holdings ph "
+                "WHERE ph.portfolio_id = v.portfolio_id "
+                "AND ph.company_id = v.company_id"
+                ")"
+            )
+            await conn.execute(
+                "INSERT INTO recommendations "
+                "(morning_note_id, action, confidence, justification) "
+                "SELECT id, 'buy', 0.8, 'Strong fundamentals' "
+                "FROM morning_notes WHERE note_text = 'note-a1' "
+                "AND NOT EXISTS (SELECT 1 FROM recommendations r WHERE r.morning_note_id = morning_notes.id)"
+                "UNION ALL "
+                "SELECT id, 'hold', 0.6, 'Mixed signals' "
+                "FROM morning_notes WHERE note_text = 'note-b1' "
+                "AND NOT EXISTS (SELECT 1 FROM recommendations r WHERE r.morning_note_id = morning_notes.id)"
+            )
+            await conn.execute("GRANT SELECT ON managers TO rls_test")
+            await conn.execute("GRANT SELECT ON companies TO rls_test")
+            await conn.execute("GRANT SELECT ON portfolios TO rls_test")
+            await conn.execute("GRANT SELECT ON portfolio_holdings TO rls_test")
+            await conn.execute("GRANT SELECT ON recommendations TO rls_test")
+            await conn.execute("GRANT INSERT, UPDATE ON recommendations TO rls_test")
+            await conn.execute("GRANT USAGE ON ALL SEQUENCES IN SCHEMA public TO rls_test")
         finally:
             await conn.close()
 

--- a/tests/integration/test_rls.py
+++ b/tests/integration/test_rls.py
@@ -37,3 +37,71 @@ async def test_rls_filters_by_manager_id(rls_role: str) -> None:
             await _count_visible(conn)
     finally:
         await conn.close()
+
+
+async def test_rls_managers_world_readable(rls_role: str) -> None:
+    conn = await _connect_as_role(rls_role)
+    try:
+        await _set_manager_id(conn, "2")
+        assert await conn.fetchval("SELECT count(*) FROM managers") == 2
+        await _set_manager_id(conn, "3")
+        assert await conn.fetchval("SELECT count(*) FROM managers") == 2
+    finally:
+        await conn.close()
+
+
+async def test_rls_companies_world_readable(rls_role: str) -> None:
+    conn = await _connect_as_role(rls_role)
+    try:
+        await _set_manager_id(conn, "2")
+        assert await conn.fetchval("SELECT count(*) FROM companies") == 1
+        await _set_manager_id(conn, "3")
+        assert await conn.fetchval("SELECT count(*) FROM companies") == 1
+    finally:
+        await conn.close()
+
+
+async def test_rls_portfolios_isolated(rls_role: str) -> None:
+    conn = await _connect_as_role(rls_role)
+    try:
+        await _set_manager_id(conn, "2")
+        assert await conn.fetchval("SELECT count(*) FROM portfolios") == 1
+        await _set_manager_id(conn, "3")
+        assert await conn.fetchval("SELECT count(*) FROM portfolios") == 1
+    finally:
+        await conn.close()
+
+
+async def test_rls_portfolio_holdings_isolated(rls_role: str) -> None:
+    conn = await _connect_as_role(rls_role)
+    try:
+        await _set_manager_id(conn, "2")
+        assert await conn.fetchval("SELECT count(*) FROM portfolio_holdings") == 1
+        await _set_manager_id(conn, "3")
+        assert await conn.fetchval("SELECT count(*) FROM portfolio_holdings") == 1
+    finally:
+        await conn.close()
+
+
+async def test_rls_recommendations_isolated(rls_role: str) -> None:
+    conn = await _connect_as_role(rls_role)
+    try:
+        await _set_manager_id(conn, "2")
+        assert await conn.fetchval("SELECT count(*) FROM recommendations") == 1
+        await _set_manager_id(conn, "3")
+        assert await conn.fetchval("SELECT count(*) FROM recommendations") == 1
+    finally:
+        await conn.close()
+
+
+async def test_rls_recommendations_insert_cross_tenant_rejected(rls_role: str) -> None:
+    conn = await _connect_as_role(rls_role)
+    try:
+        await _set_manager_id(conn, "2")
+        with pytest.raises(asyncpg.exceptions.InsufficientPrivilegeError):
+            await conn.execute(
+                "INSERT INTO recommendations (morning_note_id, action, confidence, justification) "
+                "VALUES (3, 'buy', 0.9, 'steal')"
+            )
+    finally:
+        await conn.close()


### PR DESCRIPTION
## What this PR does

- New alembic migration `1700dce69c30` enables RLS on `managers`, `companies`, `portfolios`, `portfolio_holdings`, `recommendations`
- `managers` and `companies` use `USING (true) WITH CHECK (true)` — reference tables that must be readable before the session knows who is logged in
- `portfolios` filters directly on `manager_id`
- `portfolio_holdings` and `recommendations` filter via correlated `EXISTS` subqueries through their parent table (`portfolios.manager_id` and `morning_notes.manager_id` respectively)
- Follow-up migration `a74d884aeda7` adds `WITH CHECK` to the existing `morning_notes_manager_isolation` policy. See Decisions #2 — needed because alembic does not re-run already-applied migrations.
- 6 new probes in `tests/integration/test_rls.py`:
  - 1 visibility probe per table (5) asserting per-manager row counts
  - 1 behavioral probe that attempts a cross-tenant INSERT into `recommendations` and asserts Postgres rejects it with `InsufficientPrivilegeError`
- `tests/conftest.py` refactored for idempotency — required because the prior fixture only worked for single-test runs

## What this PR does NOT do

- **Issue #03b** — split app/migration database roles (`finagent_app` vs elevated migration role). Separate PR.
- **Issue #03c** — HNSW reindex-on-insert operator script. Separate issue, not in scope of #03a.
- **Morning notes natural-key uniqueness** — `(portfolio_id, note_text)` is not a unique constraint. The fixture's `WHERE NOT EXISTS` makes the *test* idempotent, but production code can still insert duplicate rows. Future ADR / migration.

## How to verify

```bash
# Run the RLS probe suite (requires Docker)
uv run pytest tests/integration/test_rls.py -v
```

Expected: 7 passed (1 existing morning_notes probe + 6 new probes).

```bash
# Verify migrations apply cleanly against an existing DB
export DATABASE_URL="postgresql+asyncpg://finagent:finagent_secure_pass@localhost:5432/finagent"
uv run alembic upgrade head

# Confirm all 6 policies have WITH CHECK
docker exec <container> psql -U finagent -d finagent -c   "SELECT tablename, policyname, with_check IS NOT NULL AS has_with_check    FROM pg_policies ORDER BY tablename;"
```

Expected: 6 rows, all with `has_with_check = t`.

## Decisions worth flagging

1. **`recommendations` joins `morning_notes`, not `portfolios`.** `Recommendation` has no direct `manager_id` column — only `morning_note_id` FK. The original migration draft joined `portfolios` by mistake; the probe would have silently passed while leaving a real cross-tenant leak. Now correctly traverses the chain.
2. **WITH CHECK on morning_notes via follow-up migration, not in-place edit.** First version of this PR edited `1d4e6f8a2b35` in place to add WITH CHECK. After running `alembic upgrade head` against a DB that had already run issue #03's migration, `pg_policies` showed `morning_notes` still had USING only. Reason: alembic only runs migrations whose revision is not yet in `alembic_version`. In-place edits to applied migrations are dead code on production. The fix is to revert the in-place edit and add a new migration that does `ALTER POLICY ... WITH CHECK (...)`. Fresh DBs and existing DBs now converge on the same policy shape.
3. **Behavioral probe uses `InsufficientPrivilegeError`, not `RaiseError`.** Postgres raises SQLSTATE 42501 (`InsufficientPrivilegeError`) for RLS policy violations — the same class as `GRANT` failures, by design (no leakage of policy structure). The probe asserts the actual exception class; the message ("new row violates row-level security policy") confirms the cause.
4. **Fixture idempotency uses `SELECT FROM (VALUES ...) AS v(...) WHERE NOT EXISTS`** for tables without a unique constraint that matches the seed's natural key. `ON CONFLICT (id) DO NOTHING` alone is insufficient when ids are auto-generated and the seed's logical uniqueness lives in a composite key.

Closes #31