### PR TITLE
feat(issue-07): Closes #7 — typed AgentState with validate_state guard

### DIFF
--- a/app/graph/state.py
+++ b/app/graph/state.py
@@ -1,6 +1,7 @@
+from datetime import datetime
 from typing import TypedDict, Literal
 
-from app.utils.flags import Severity
+from app.utils.flags import DataFlag, Severity
 
 
 class MacroOutput(TypedDict, total=False):
@@ -38,3 +39,43 @@ class RecommendationPayload(TypedDict, total=False):
     justification: str
     confidence: float
     created_at: str
+
+
+class AgentState(TypedDict):
+    pipeline_run_id: str
+    morning_note_id: str
+    manager_id: int
+    company_ticker: str
+    macro_context: MacroOutput | None
+    company_events: list[CompanyEvent]
+    quant_metrics: QuantOutput | None
+    risk_flags: list[RiskFlag]
+    morning_note: str | None
+    recommendation: RecommendationPayload | None
+    confidence_scores: dict[str, float]
+    data_freshness: dict[str, datetime]
+    flags: list[DataFlag]
+
+
+def create_initial_state(
+        *,
+        manager_id: int,
+        company_ticker: str,
+        pipeline_run_id: str,
+        morning_note_id: str
+) -> AgentState:
+    return {
+        "manager_id": manager_id,
+        "company_ticker": company_ticker,
+        "pipeline_run_id": pipeline_run_id,
+        "morning_note_id": morning_note_id,
+        "macro_context": None,
+        "company_events": [],
+        "quant_metrics": None,
+        "risk_flags": [],
+        "morning_note": None,
+        "recommendation": None,
+        "confidence_scores": {},
+        "data_freshness": {},
+        "flags": [],
+    }

--- a/app/graph/state.py
+++ b/app/graph/state.py
@@ -1,0 +1,40 @@
+from typing import TypedDict, Literal
+
+from app.utils.flags import Severity
+
+
+class MacroOutput(TypedDict, total=False):
+    headline: str
+    summary: str
+    sources: list[str]
+    fetched_at: str
+
+
+class CompanyEvent(TypedDict, total=False):
+    title: str
+    date: str
+    source: str
+    summary: str
+
+
+class QuantOutput(TypedDict, total=False):
+    pl: float
+    ev_ebitda: float
+    p_vpa: float
+    dividend_yield: float
+    dev_ibov: float
+    fetched_at: str
+
+
+class RiskFlag(TypedDict, total=False):
+    probability: float
+    impact: Literal["low", "medium", "high"]
+    description: str
+    severity: Severity
+
+
+class RecommendationPayload(TypedDict, total=False):
+    action: Literal["buy", "sell", "keep"]
+    justification: str
+    confidence: float
+    created_at: str

--- a/app/graph/state.py
+++ b/app/graph/state.py
@@ -79,3 +79,33 @@ def create_initial_state(
         "data_freshness": {},
         "flags": [],
     }
+
+
+class InvalidStateError(ValueError):
+    """Raised when an AgentState fails invariant validation."""
+
+
+def validate_state(state: AgentState) -> None:
+    """Validate AgentState invariants. Raises InvalidStateError on violation.
+
+    Invariants:
+    - state["manager_id"] is a positive int (RLS invariant)
+    - RiskFlag.severity values are valid Severity members (if risk_flags present)
+    - RiskFlag.probability values are in [0.0, 1.0] (if risk_flags present)
+    """
+    manager_id = state.get("manager_id")
+
+    if manager_id is None:
+        raise InvalidStateError(f"AgentState missing required field 'manager_id', got {manager_id}.")
+    if not (isinstance(manager_id, int) and manager_id > 0):
+        raise InvalidStateError(f"AgentState.manager_id must be a positive int, got {manager_id}.")
+
+    for flag in state.get("risk_flags", []):
+        severity = flag.get("severity")
+        prob = flag.get("probability")
+
+        if severity is not None and severity not in Severity.__members__.values():
+            raise InvalidStateError(f"RiskFlag.severity must be a valid Severity, got {severity!r}.")
+        if prob is not None and not 0.0 <= prob <= 1.0:
+            raise InvalidStateError(f"RiskFlag.probability must be in [0.0, 1.0], got {prob}.")
+    

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -1,0 +1,108 @@
+import pytest
+
+from app.graph.state import create_initial_state, validate_state, InvalidStateError
+from app.utils.flags import Severity
+
+
+def test_validate_state_rejects_missing_manager_id() -> None:
+    state = {
+        "company_ticker": "PETR4",
+        "pipeline_run_id": "pipeline_run_id",
+        "morning_note_id": "morning_note_id",
+        "macro_context": None,
+        "company_events": [],
+        "quant_metrics": None,
+        "risk_flags": [],
+        "morning_note": None,
+        "recommendation": None,
+        "confidence_scores": {},
+        "data_freshness": {},
+        "flags": [],
+    }
+    with pytest.raises(InvalidStateError, match="manager_id"):
+        validate_state(state)
+
+
+def test_validate_state_rejects_invalid_manager_id() -> None:
+    state = {
+        "manager_id": -10,
+        "company_ticker": "PETR4",
+        "pipeline_run_id": "pipeline_run_id",
+        "morning_note_id": "morning_note_id",
+        "macro_context": None,
+        "company_events": [],
+        "quant_metrics": None,
+        "risk_flags": [],
+        "morning_note": None,
+        "recommendation": None,
+        "confidence_scores": {},
+        "data_freshness": {},
+        "flags": [],
+    }
+    with pytest.raises(InvalidStateError, match="manager_id"):
+        validate_state(state)
+
+
+def test_validate_state_rejects_invalid_severity() -> None:
+    state = {
+        "manager_id": 1,
+        "company_ticker": "PETR4",
+        "pipeline_run_id": "pipeline_run_id",
+        "morning_note_id": "morning_note_id",
+        "macro_context": None,
+        "company_events": [],
+        "quant_metrics": None,
+        "risk_flags": [
+            {
+                "probability": 0.1,
+                "impact": "low",
+                "description": "Inflação acima do esperado aumenta risco de alta adicional da Selic.",
+                "severity": "a"
+            }
+        ],
+        "morning_note": None,
+        "recommendation": None,
+        "confidence_scores": {},
+        "data_freshness": {},
+        "flags": [],
+    }
+    with pytest.raises(InvalidStateError, match="severity"):
+        validate_state(state)
+    
+
+def test_validate_state_rejects_invalid_probability() -> None:
+    state = {
+        "manager_id": 1,
+        "company_ticker": "PETR4",
+        "pipeline_run_id": "pipeline_run_id",
+        "morning_note_id": "morning_note_id",
+        "macro_context": None,
+        "company_events": [],
+        "quant_metrics": None,
+        "risk_flags": [
+            {
+                "probability": 10,
+                "impact": "low",
+                "description": "Inflação acima do esperado aumenta risco de alta adicional da Selic.",
+                "severity": Severity.WARNING
+            }
+        ],
+        "morning_note": None,
+        "recommendation": None,
+        "confidence_scores": {},
+        "data_freshness": {},
+        "flags": [],
+    }
+    with pytest.raises(InvalidStateError, match="probability"):
+        validate_state(state)
+
+
+def test_validate_state_accepts_valid_state() -> None:
+    state = create_initial_state(
+        manager_id=1, 
+        company_ticker="PETR4", 
+        pipeline_run_id="run-123", 
+        morning_note_id="note-123"
+    )
+    validate_state(state)
+    


### PR DESCRIPTION
## What this PR does

Closes #7. Adds typed state schema for the FinAgent pipeline.

- `app/graph/state.py`:
  - Five payload TypedDicts: `MacroOutput`, `CompanyEvent`, `QuantOutput`, `RiskFlag`, `RecommendationPayload`.
  - `AgentState` TypedDict (13 fields, manager_id required as int).
  - `create_initial_state(*, manager_id, company_ticker, pipeline_run_id, morning_note_id) -> AgentState` factory with keyword-only args.
  - `InvalidStateError(ValueError)` and `validate_state(state) -> None` with three invariants: positive-int manager_id (RLS gate), valid Severity values, probability in [0.0, 1.0].
- `tests/unit/test_state.py`: 5 unit tests covering the three rejection paths and one positive path.

## What this PR does NOT do

- Does not implement the agents that populate this state (#08 MacroAgent, #09 CompanyAgent, #10 QuantAgent, etc.).
- Does not wire `validate_state()` into a LangGraph node — that belongs to #14 (StateGraph assembly).
- Does not promote `MacroOutput.sources: list[str]` to a richer shape — see #52 (follow-up).
- Does not loosen `validate_state()`'s severity check to accept string values alongside the enum — see follow-up issue TBD.

## How to verify

```bash
uv run pytest tests/unit/test_state.py -v
uv run pytest tests/unit/ -q
uv run mypy app/graph/state.py
```

Expected: 5 new tests pass, 13 total unit tests pass, mypy clean.

Manual smoke:

```bash
uv run python -c "
from app.graph.state import create_initial_state, validate_state
state = create_initial_state(manager_id=42, company_ticker='PETR4', pipeline_run_id='run-1', morning_note_id='note-1')
validate_state(state)
print('valid state accepted')
"
```

## Decisions worth flagging

1. **Payload TypedDicts live in `app/graph/state.py`, not `app/utils/`.** Convention from `docs/finagent-CLAUDE.md` and journal entries 12/13: shape-only types live where they're used; behavior-bearing classes (DataFlag, validators) live in `utils/`. None of the five payloads have methods today, so they're shape-only and stay in `state.py`. If any grows methods, see #53.

2. **`RecommendationPayload` is a separate type from the SQLAlchemy `Recommendation` model.** The graph payload is the conceptual thing the EditorAgent produces; the DB row is the persistence artifact. They have different shapes (payload has no `id`/`created_at` columns; DB row has no `manager_id` in payload form). Persistence boundary (issue #20) will convert between them. This contradicts `docs/finagent-CLAUDE.md:105` which uses the name `Recommendation` — we are intentionally not editing the spec doc per repo convention.

3. **`manager_id: int` (not `str`).** Matches the DB column (`app/db/models.py:76`) and the RLS cast (`current_setting('app.manager_id', true)::int`). State carrying `int` is required for the persistence boundary to not coerce.

4. **Field names are English.** `company_ticker` (not `empresa_ticker`), `manager_id` (not `gestor_id` in field name, though the RLS GUC remains `app.manager_id` per the existing DB migrations). This contradicts `docs/finagent-CLAUDE.md:98-99` — same as decision 2, intentionally not editing the spec doc.

5. **`create_initial_state()` uses keyword-only arguments.** Forces callers to name each required field. Positional calls would be ambiguous.

6. **Severity check in `validate_state()` is strict (enum members only, not string values).** Agents emitting strings (e.g., from JSON deserialization or LLM output) will fail this check. Loosening to `severity in {s.value for s in Severity}` is a follow-up. Tracked separately.

7. **`validate_state()` raises typed `InvalidStateError(ValueError)`, not bare `ValueError`.** Sets up the pattern for future subclasses (`MissingManagerIdError`, `InvalidSeverityError`, etc.) when the project needs to discriminate exception types at call sites.
