### PR TITLE
refactor(tavily): Closes #62 — extract TavilyService class

### DIFF
--- a/app/agents/company.py
+++ b/app/agents/company.py
@@ -1,12 +1,12 @@
 from datetime import datetime, UTC
 
 import logging
-import httpx
 
 from app.core.config import settings
 from app.graph.state import AgentState, CompanyEvent
 from app.prompts.company import COMPANY_PROMPTS
 from app.services.llm import summarize
+from app.services.tavily import TavilyService, TavilyConfigError
 from app.utils.flags import DataFlag, Severity
 
 
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 async def company_agent_node(state: AgentState) -> AgentState:
-    """Pull company news via Tavily for the ticker in state, extract
+    """Pull company news via TavilyService for ticker in state, extract
     CompanyEvents via NVIDIA NIM, and update AgentState in-place.
     Failures append a DataFlag and return - never raises.
     """
@@ -27,67 +27,40 @@ async def company_agent_node(state: AgentState) -> AgentState:
         }
     )
 
-
-    tavily_key = settings.TAVILY_API_KEY
-    if not tavily_key:
+    try:
+        tavily = TavilyService(api_key=settings.TAVILY_API_KEY)
+    except TavilyConfigError as exc:
         state["flags"].append(
             DataFlag(
                 source="tavily",
                 severity=Severity.FATAL,
-                message="TAVILY_API_KEY missing"
+                message=str(exc)
             )
         )
         state["company_events"] = []
         state["data_freshness"]["company"] = datetime.now(UTC)
         return state
 
-
     ticker = state["company_ticker"]
-    payload = {
-        "query": f"{ticker} news Brazil",
-        "max_results": 10,
-        "include_domains": [
+    result = await tavily.search(
+        query=f"{ticker} news Brazil",
+        include_domains=[
             "cvm.gov.br",
             "infomoney.com.br",
             "globo.com/valor-economico"
-        ]
-    }
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.post(
-                "https://api.tavily.com/search",
-                headers={"Authorization": f"Bearer {tavily_key}"},
-                json=payload
-            )
-            resp.raise_for_status()
-            data = resp.json()
-    except Exception as exc:
-        state["flags"].append(
-            DataFlag(
-                source="tavily",
-                severity=Severity.WARNING,
-                message=f"Tavily request error: {exc}"
-            )
-        )
+        ],
+        max_results=10
+    )
+    if result.error:
+        state["flags"].append(result.error)
         state["company_events"] = []
         state["data_freshness"]["company"] = datetime.now(UTC)
         return state
 
-
     company_events: list[CompanyEvent] = []
-    try:
-        if not data or not data.get("results"):
-            raise ValueError("Tavily returned no results field")
-        top = data["results"][0]
-        if not (top.get("title") and top.get("content")):
-            raise ValueError(
-                f"Tavily returned results with null title/content for "
-                f"{ticker} - schema may have changed"
-            )
-        raw_text = (
-            f"{top.get('title', '')}\n\n"
-            f"{top.get('content', '')}\n{top.get('url', '')}"
-        )
+    if result.articles:
+        top = result.articles[0]
+        raw_text = f"{top.title or ''}\n\n{top.content or ''}\n{top.url or ''}"
 
         summary = await summarize(
             system=COMPANY_PROMPTS.system,
@@ -102,27 +75,16 @@ async def company_agent_node(state: AgentState) -> AgentState:
                     message="Summarization returned None; using raw content"
                 )
             )
-            summary = top.get("content", "")
+            summary = top.content or ""
 
         company_events.append(
             CompanyEvent(
-                title=str(top.get("title", "")),
+                title=top.title or "",
                 date="",
-                source=str(top.get("url", "")),
+                source=top.url or "",
                 summary=summary
             )
         )
-    except (ValueError, KeyError, IndexError) as exc:
-        state["flags"].append(
-            DataFlag(
-                source="tavily",
-                severity=Severity.FATAL,
-                message=f"parse-block failed for {state['company_ticker']}: {exc}"
-            )
-        )
-        state["company_events"] = []
-        state["data_freshness"]["company"] = datetime.now(UTC)
-        return state
 
     state["company_events"] = company_events
     state["data_freshness"]["company"] = datetime.now(UTC)

--- a/app/agents/macro.py
+++ b/app/agents/macro.py
@@ -1,78 +1,70 @@
 from datetime import datetime, UTC
-import logging
 
-import httpx
+import logging
 
 from app.core.config import settings
 from app.graph.state import AgentState, MacroOutput
 from app.prompts.macro import MACRO_PROMPTS
 from app.services.llm import summarize
+from app.services.tavily import TavilyService, TavilyConfigError
 from app.utils.flags import DataFlag, Severity
+
 
 logger = logging.getLogger(__name__)
 
 
 async def macro_agent_node(state: AgentState) -> AgentState:
-    """Pull macro-news via Tavily, build a MacroOutput, and update
-    the AgentState in-place. Failures append a DataFlag and return
-    with macro_context=None — never raises.
+    """Pull macro-news via TavilyService, build a MacroOutput, and update
+    AgentState in-place. Failures append a DataFlag and returns
+    with macro_context=None - never raises.
     """
     logger.info(
         "macro_agent_start",
         extra={
             "pipeline_run_id": state["pipeline_run_id"],
             "morning_note_id": state["morning_note_id"],
-            "manager_id": state["manager_id"],
-        },
+            "manager_id": state["manager_id"]
+        }
     )
 
-    tavily_key = settings.TAVILY_API_KEY
-    if not tavily_key:
+    try:
+        tavily = TavilyService(api_key=settings.TAVILY_API_KEY)
+    except TavilyConfigError as exc:
         state["flags"].append(
             DataFlag(
                 source="tavily",
                 severity=Severity.FATAL,
-                message="TAVILY_API_KEY missing",
+                message=str(exc)
             )
         )
         state["macro_context"] = None
         state["data_freshness"]["macro"] = datetime.now(UTC)
         return state
 
-    payload = {"query": "macro news Brazil", "max_results": 10,
-               "include_domains": ["bcb.gov.br", "ibge.gov.br", "br.reuters.com", "bloomberg.com.br"]}
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.post(
-                "https://api.tavily.com/search",
-                headers={"Authorization": f"Bearer {tavily_key}"},
-                json=payload,
-            )
-            resp.raise_for_status()
-            data = resp.json()
-    except Exception as exc:
-        state["flags"].append(
-            DataFlag(
-                source="tavily",
-                severity=Severity.WARNING,
-                message=f"Tavily request error: {exc}",
-            )
-        )
+    result = await tavily.search(
+        query="macro news Brazil",
+        include_domains=[
+            "bcb.gov.br", 
+            "ibge.gov.br", 
+            "br.reuters.com", 
+            "bloomberg.com.br"
+        ],
+        max_results=10
+    )
+    if result.error:
+        state["flags"].append(result.error)
         state["macro_context"] = None
         state["data_freshness"]["macro"] = datetime.now(UTC)
         return state
 
     macro_output: MacroOutput | None = None
-    if data and data.get("results"):
-        top = data["results"][0]
-        raw_text = (
-            f"{top.get('title', '')}\n\n"
-            f"{top.get('content', '')}\n{top.get('url', '')}"
-        )
+    if result.articles:
+        top = result.articles[0]
+        raw_text = f"{top.title or ''}\n\n{top.content or ''}\n{top.url or ''}"
 
         summary = await summarize(
             system=MACRO_PROMPTS.system,
-            user=MACRO_PROMPTS.build_user_prompt(raw_text=raw_text),
+            user=MACRO_PROMPTS.build_user_prompt(raw_text=raw_text)
         )
 
         if summary is None:
@@ -80,16 +72,16 @@ async def macro_agent_node(state: AgentState) -> AgentState:
                 DataFlag(
                     source="nvidia_nim",
                     severity=Severity.WARNING,
-                    message="Summarization returned None; using raw content.",
+                    message="Summarization returned None; using raw content"
                 )
             )
-            summary = top.get("content", "")
+            summary = top.content or ""
 
         macro_output = MacroOutput(
-            headline=str(top.get("title", "")),
+            headline=top.title or "",
             summary=summary,
-            sources=[str(top.get("url", ""))] if top.get("url") else [],
-            fetched_at=datetime.now(UTC).isoformat(),
+            sources=[top.url] if top.url else [],
+            fetched_at=datetime.now(UTC).isoformat()
         )
 
     state["macro_context"] = macro_output

--- a/app/agents/macro.py
+++ b/app/agents/macro.py
@@ -78,7 +78,7 @@ async def macro_agent_node(state: AgentState) -> AgentState:
         if summary is None:
             state["flags"].append(
                 DataFlag(
-                    source="tavily",
+                    source="nvidia_nim",
                     severity=Severity.WARNING,
                     message="Summarization returned None; using raw content.",
                 )

--- a/app/services/tavily.py
+++ b/app/services/tavily.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import httpx
+from dataclasses import dataclass
+
+from app.core.config import settings
+from app.utils.flags import DataFlag, Severity
+
+
+class TavilyError(Exception):
+    """Base for all TavilyService failures. Callers can `except TavilyError:` as catch-all."""
+
+
+class TavilyConfigError(TavilyError):
+    """Raised when the service cannot be constructed (e.g. missing API key)"""
+
+
+class TavilyRequestError(TavilyError):
+    """Internal: HTTP/network failure. Surfaced via TavilyResult.error, never raised across the boundary"""
+
+
+class TavilyParseError(TavilyError):
+    """Internal: bad response shape. Surfaced via TavilyResult.error, never raised across the boundary."""
+
+
+@dataclass(frozen=True)
+class TavilyArticle:
+    title: str | None
+    content: str | None
+    url: str | None
+
+
+@dataclass(frozen=True)
+class TavilyResult:
+    articles: list[TavilyArticle]
+    error: DataFlag | None
+
+
+class TavilyService:
+    def __init__(self, api_key: str | None = None, timeout: float = 10.0) -> None:
+        key = api_key if api_key is not None else settings.TAVILY_API_KEY
+        if not key:
+            raise TavilyConfigError("TAVILY_API_KEY missing or empty")
+        self.api_key = key
+        self.timeout = timeout
+
+    async def search(
+            self,
+            query: str,
+            include_domains: list[str],
+            max_results: int = 10
+    ) -> TavilyResult:
+        payload = {
+            "query": query,
+            "max_results": max_results,
+            "include_domains": include_domains
+        }
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                resp = await client.post(
+                    "https://api.tavily.com/search",
+                    headers={"Authorization": f"Bearer {self.api_key}"},
+                    json=payload
+                )
+                resp.raise_for_status()
+                data = resp.json()
+        except Exception as exc:
+            return TavilyResult(
+                articles=[],
+                error=DataFlag(
+                    source="tavily",
+                    severity=Severity.WARNING,
+                    message=f"Tavily request error: {exc}"
+                )
+            )
+
+        raw_articles = data.get("results") or []
+        articles: list[TavilyArticle] = []
+        for raw in raw_articles:
+            if not isinstance(raw, dict):
+                continue
+            article = TavilyArticle(
+                title=raw.get("title"),
+                content=raw.get("content"),
+                url=raw.get("url")
+            )
+            articles.append(article)
+
+        if articles and any(a.title is None or a.content is None for a in articles):
+            return TavilyResult(
+                articles=[],
+                error=DataFlag(
+                    source="tavily",
+                    severity=Severity.FATAL,
+                    message=(
+                        f"Tavily returned articles with null title/content for "
+                        f"query {query!r} - schema may have changed"
+                    )
+                )
+            )
+
+        return TavilyResult(articles=articles, error=None)
+    

--- a/tests/unit/test_company_agent.py
+++ b/tests/unit/test_company_agent.py
@@ -1,105 +1,116 @@
+import logging
+from datetime import datetime
+from unittest.mock import patch, AsyncMock
+
 import pytest
 
-from unittest.mock import AsyncMock, patch, MagicMock
-
 from app.agents.company import company_agent_node
-from app.graph.state import create_initial_state, Severity
+from app.graph.state import create_initial_state, DataFlag
+from app.services.tavily import TavilyArticle, TavilyResult
+from app.utils.flags import Severity
+
+
+def make_state():
+    return create_initial_state(
+        manager_id=1,
+        company_ticker="PETR4",
+        pipeline_run_id="run",
+        morning_note_id="note",
+    )
+
+
+def _tavily_result(articles=None, error=None):
+    return TavilyResult(articles=articles or [], error=error)
 
 
 @pytest.mark.asyncio
 async def test_company_agent_no_key():
-    with patch("app.agents.company.settings.TAVILY_API_KEY", ""):
-        state = create_initial_state(
-            manager_id=1, company_ticker="PETR4",
-            pipeline_run_id="run", morning_note_id="note",
-        )
+    from app.services.tavily import TavilyConfigError
+    with patch("app.agents.company.TavilyService", side_effect=TavilyConfigError("TAVILY_API_KEY missing or empty")):
+        state = make_state()
         result = await company_agent_node(state)
 
     assert result["company_events"] == []
-    assert any(
-        f.source == "tavily" and f.severity == Severity.FATAL
-        for f in result["flags"]
-    )
-    from datetime import datetime
+    flag = result["flags"][-1]
+    assert isinstance(flag, DataFlag)
+    assert flag.source == "tavily"
+    assert flag.severity == Severity.FATAL
     assert isinstance(result["data_freshness"]["company"], datetime)
 
 
 @pytest.mark.asyncio
 async def test_company_agent_llm_none():
-    tavily_json = {
-        "results": [
-            {
-                "title": "PETR4 earnings Q3",
-                "content": "Petrobras reported record earnings...",
-                "url": "https://infomoney.com.br/petr4",
-            }
-        ]
-    }
+    article = TavilyArticle(
+        title="PETR4 earnings Q3",
+        content="Petrobras reported record earnings...",
+        url="https://infomoney.com.br/petr4",
+    )
+    result = _tavily_result(articles=[article])
 
-    mock_client = AsyncMock()
-    mock_resp = MagicMock()
-    mock_resp.json.return_value = tavily_json
-    mock_resp.raise_for_status = MagicMock()
-    mock_client.post.return_value = mock_resp
-    mock_client.__aenter__.return_value = mock_client
+    with patch("app.agents.company.TavilyService") as MockService:
+        MockService.return_value.search = AsyncMock(return_value=result)
+        with patch("app.agents.company.summarize", new=AsyncMock(return_value=None)):
+            state = make_state()
+            res = await company_agent_node(state)
 
-    async def summarize_returns_none(system, user):
-        return None
-
-    with patch("app.agents.company.settings.TAVILY_API_KEY", "dummy"):
-        with patch("app.agents.company.httpx.AsyncClient", return_value=mock_client):
-            with patch("app.agents.company.summarize", side_effect=summarize_returns_none):
-                state = create_initial_state(
-                    manager_id=1, company_ticker="PETR4",
-                    pipeline_run_id="run", morning_note_id="note",
-                )
-                result = await company_agent_node(state)
-
-    events = result["company_events"]
+    events = res["company_events"]
     assert len(events) == 1
     assert events[0]["summary"] == "Petrobras reported record earnings..."
-    flag = result["flags"][-1]
+    flag = res["flags"][-1]
+    assert isinstance(flag, DataFlag)
     assert flag.source == "nvidia_nim"
 
 
 @pytest.mark.asyncio
 async def test_company_agent_happy_path():
-    tavily_json = {
-        "results": [
-            {
-                "title": "PETR4 earnings Q3",
-                "content": "Petrobras reported record earnings...",
-                "url": "https://infomoney.com.br/petr4",
-            }
-        ]
-    }
+    article = TavilyArticle(
+        title="PETR4 earnings Q3",
+        content="Petrobras reported record earnings...",
+        url="https://infomoney.com.br/petr4",
+    )
+    result = _tavily_result(articles=[article])
 
-    mock_client = AsyncMock()
-    mock_resp = MagicMock()
-    mock_resp.json.return_value = tavily_json
-    mock_resp.raise_for_status = MagicMock()
-    mock_client.post.return_value = mock_resp
-    mock_client.__aenter__.return_value = mock_client
+    with patch("app.agents.company.TavilyService") as MockService:
+        MockService.return_value.search = AsyncMock(return_value=result)
+        with patch("app.agents.company.summarize", new=AsyncMock(return_value="Resumo de earnings da Petrobras.")):
+            state = make_state()
+            res = await company_agent_node(state)
 
-    async def fake_summarize(system: str, user: str):
-        return "Resumo de earnings da Petrobras."
-
-    with patch("app.agents.company.settings.TAVILY_API_KEY", "dummy"):
-        with patch("app.agents.company.httpx.AsyncClient", return_value=mock_client):
-            with patch("app.agents.company.summarize", side_effect=fake_summarize):
-                state = create_initial_state(
-                    manager_id=1, company_ticker="PETR4",
-                    pipeline_run_id="run", morning_note_id="note",
-                )
-                result = await company_agent_node(state)
-
-    events = result["company_events"]
+    events = res["company_events"]
     assert len(events) == 1
     assert events[0]["title"] == "PETR4 earnings Q3"
     assert events[0]["summary"] == "Resumo de earnings da Petrobras."
     assert events[0]["source"] == "https://infomoney.com.br/petr4"
-    from datetime import datetime
-    assert isinstance(result["data_freshness"]["company"], datetime)
-    assert result["flags"] == []
+    assert isinstance(res["data_freshness"]["company"], datetime)
+    assert res["flags"] == []
 
 
+@pytest.mark.asyncio
+async def test_company_agent_tavily_service_error():
+    error = DataFlag(source="tavily", severity=Severity.WARNING, message="Tavily request error: network down")
+    result = _tavily_result(error=error)
+
+    with patch("app.agents.company.TavilyService") as MockService:
+        MockService.return_value.search = AsyncMock(return_value=result)
+        state = make_state()
+        res = await company_agent_node(state)
+
+    assert res["company_events"] == []
+    flag = res["flags"][-1]
+    assert isinstance(flag, DataFlag)
+    assert flag.source == "tavily"
+    assert flag.severity == Severity.WARNING
+
+
+@pytest.mark.asyncio
+async def test_company_agent_logs_entry(caplog):
+    with caplog.at_level(logging.INFO, logger="app.agents.company"):
+        with patch("app.agents.company.TavilyService") as MockService:
+            MockService.return_value.search = AsyncMock(return_value=_tavily_result())
+            await company_agent_node(make_state())
+    records = [r for r in caplog.records if r.name == "app.agents.company"]
+    assert len(records) >= 1
+    rec = records[0]
+    assert rec.pipeline_run_id == "run"
+    assert rec.morning_note_id == "note"
+    assert rec.manager_id == 1

--- a/tests/unit/test_company_agent_stub.py
+++ b/tests/unit/test_company_agent_stub.py
@@ -1,59 +1,45 @@
+"""Stub tests covering the agent-side propagation of TavilyService errors
+that originate from bad response shapes (the contract handoff from the
+old inline parse-block guard to the new service-level guard).
+"""
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import patch, AsyncMock
 
 from app.agents.company import company_agent_node
-from app.graph.state import create_initial_state, Severity
+from app.graph.state import create_initial_state, DataFlag
+from app.services.tavily import TavilyResult
+from app.utils.flags import Severity
 
 
-@pytest.mark.asyncio
-async def test_company_agent_no_key():
-    with patch("app.agents.company.settings.TAVILY_API_KEY", ""):
-        state = create_initial_state(
-            manager_id=1, company_ticker="PETR4",
-            pipeline_run_id="run", morning_note_id="note",
-        )
-        result = await company_agent_node(state)
-
-    assert result["company_events"] == []
-    assert any(
-        f.source == "tavily" and f.severity == Severity.FATAL
-        for f in result["flags"]
+def make_state():
+    return create_initial_state(
+        manager_id=1, company_ticker="PETR4",
+        pipeline_run_id="run", morning_note_id="note",
     )
-    from datetime import datetime
-    assert isinstance(result["data_freshness"]["company"], datetime)
-
-
-async def _summarize_returns_none(system, user):
-    return None
 
 
 @pytest.mark.asyncio
-async def test_company_agent_all_null_fields():
-    """Tavily returns results[0] with null title/content → FATAL DataFlag, no raise."""
-    tavily_json = {
-        "results": [{"title": None, "content": None, "url": None}]
-    }
+async def test_company_agent_propagates_service_fatal_for_null_fields():
+    """Service detects null title/content and returns a FATAL DataFlag.
+    The agent must propagate it (not swallow, not re-validate), set
+    company_events to empty, and return early.
+    """
+    error = DataFlag(
+        source="tavily",
+        severity=Severity.FATAL,
+        message="Tavily returned articles with null title/content for query 'PETR4 news Brazil' - schema may have changed",
+    )
+    result = TavilyResult(articles=[], error=error)
 
-    mock_client = AsyncMock()
-    mock_resp = MagicMock()
-    mock_resp.json.return_value = tavily_json
-    mock_resp.raise_for_status = MagicMock()
-    mock_client.post.return_value = mock_resp
-    mock_client.__aenter__.return_value = mock_client
+    with patch("app.agents.company.TavilyService") as MockService:
+        MockService.return_value.search = AsyncMock(return_value=result)
+        state = make_state()
+        res = await company_agent_node(state)
 
-    with patch("app.agents.company.settings.TAVILY_API_KEY", "dummy"):
-        with patch("app.agents.company.httpx.AsyncClient", return_value=mock_client):
-            with patch("app.agents.company.summarize", side_effect=_summarize_returns_none):
-                state = create_initial_state(
-                    manager_id=1, company_ticker="PETR4",
-                    pipeline_run_id="run-null", morning_note_id="note-null",
-                )
-                result = await company_agent_node(state)
-
-    assert result["company_events"] == []
-    assert len(result["flags"]) == 1
-    flag = result["flags"][0]
+    assert res["company_events"] == []
+    assert len(res["flags"]) == 1
+    flag = res["flags"][0]
+    assert isinstance(flag, DataFlag)
     assert flag.source == "tavily"
     assert flag.severity == Severity.FATAL
-    assert "PETR4" in flag.message
-    assert "parse-block failed" in flag.message
+    assert "PETR4 news Brazil" in flag.message

--- a/tests/unit/test_macro_agent.py
+++ b/tests/unit/test_macro_agent.py
@@ -1,10 +1,12 @@
 import logging
-import pytest
-from unittest.mock import patch, AsyncMock, MagicMock
 from datetime import datetime
+from unittest.mock import patch, AsyncMock
+
+import pytest
 
 from app.agents.macro import macro_agent_node
 from app.graph.state import create_initial_state, DataFlag
+from app.services.tavily import TavilyArticle, TavilyResult
 
 
 def make_state():
@@ -16,106 +18,97 @@ def make_state():
     )
 
 
+def _tavily_result(articles=None, error=None):
+    return TavilyResult(articles=articles or [], error=error)
+
+
 @pytest.mark.asyncio
 async def test_macro_agent_happy_path():
-    tavily_json = {
-        "results": [
-            {
-                "title": "Brazil macro outlook",
-                "content": "Inflation slowed to 3.2%…",
-                "url": "https://example.com/macro",
-            }
-        ]
-    }
+    article = TavilyArticle(
+        title="Brazil macro outlook",
+        content="Inflation slowed to 3.2%…",
+        url="https://example.com/macro",
+    )
+    result = _tavily_result(articles=[article])
 
-    mock_client = AsyncMock()
-    mock_resp = MagicMock()
-    mock_resp.json.return_value = tavily_json
-    mock_resp.raise_for_status = MagicMock()
-    mock_client.post.return_value = mock_resp
-    mock_client.__aenter__.return_value = mock_client
+    with patch("app.agents.macro.TavilyService") as MockService:
+        MockService.return_value.search = AsyncMock(return_value=result)
+        with patch("app.agents.macro.summarize", new=AsyncMock(return_value="Resumo macro de alta confiança.")):
+            state = make_state()
+            res = await macro_agent_node(state)
 
-    async def fake_summarize(system: str, user: str):
-        return "Resumo macro de alta confiança."
-
-    with patch("app.core.config.settings.TAVILY_API_KEY", "dummy"):
-        with patch("app.agents.macro.httpx.AsyncClient", return_value=mock_client):
-            with patch("app.agents.macro.summarize", side_effect=fake_summarize):
-                state = make_state()
-                result = await macro_agent_node(state)
-
-    macro = result["macro_context"]
+    macro = res["macro_context"]
     assert macro is not None
     assert macro["headline"] == "Brazil macro outlook"
     assert macro["summary"] == "Resumo macro de alta confiança."
     assert macro["sources"] == ["https://example.com/macro"]
-    # freshness should be a datetime
-    assert isinstance(result["data_freshness"]["macro"], datetime)
-    assert result["flags"] == []
+    assert isinstance(res["data_freshness"]["macro"], datetime)
+    assert res["flags"] == []
 
 
 @pytest.mark.asyncio
 async def test_macro_agent_tavily_failure():
-    mock_client = AsyncMock()
-    mock_client.post.side_effect = Exception("network down")
-    mock_client.__aenter__.return_value = mock_client
+    from app.utils.flags import Severity
+    error = DataFlag(source="tavily", severity=Severity.WARNING, message="Tavily request error: network down")
+    result = _tavily_result(error=error)
 
-    with patch("app.core.config.settings.TAVILY_API_KEY", "dummy"):
-        with patch("app.agents.macro.httpx.AsyncClient", return_value=mock_client):
-            state = make_state()
-            result = await macro_agent_node(state)
+    with patch("app.agents.macro.TavilyService") as MockService:
+        MockService.return_value.search = AsyncMock(return_value=result)
+        state = make_state()
+        res = await macro_agent_node(state)
 
-    assert result["macro_context"] is None
-    flag = result["flags"][-1]
+    assert res["macro_context"] is None
+    flag = res["flags"][-1]
     assert isinstance(flag, DataFlag)
     assert flag.source == "tavily"
-    assert isinstance(result["data_freshness"]["macro"], datetime)
+    assert isinstance(res["data_freshness"]["macro"], datetime)
+
+
+@pytest.mark.asyncio
+async def test_macro_agent_tavily_config_error():
+    from app.services.tavily import TavilyConfigError
+    with patch("app.agents.macro.TavilyService", side_effect=TavilyConfigError("TAVILY_API_KEY missing or empty")):
+        state = make_state()
+        res = await macro_agent_node(state)
+
+    assert res["macro_context"] is None
+    flag = res["flags"][-1]
+    assert isinstance(flag, DataFlag)
+    assert flag.source == "tavily"
+    assert flag.severity.value == "fatal"
 
 
 @pytest.mark.asyncio
 async def test_macro_agent_llm_none():
-    tavily_json = {
-        "results": [
-            {
-                "title": "Brazil macro outlook",
-                "content": "Inflation slowed …",
-                "url": "https://example.com/macro",
-            }
-        ]
-    }
+    article = TavilyArticle(
+        title="Brazil macro outlook",
+        content="Inflation slowed …",
+        url="https://example.com/macro",
+    )
+    result = _tavily_result(articles=[article])
 
-    mock_client = AsyncMock()
-    mock_resp = MagicMock()
-    mock_resp.json.return_value = tavily_json
-    mock_resp.raise_for_status = MagicMock()
-    mock_client.post.return_value = mock_resp
-    mock_client.__aenter__.return_value = mock_client
+    with patch("app.agents.macro.TavilyService") as MockService:
+        MockService.return_value.search = AsyncMock(return_value=result)
+        with patch("app.agents.macro.summarize", new=AsyncMock(return_value=None)):
+            state = make_state()
+            res = await macro_agent_node(state)
 
-    async def summarize_returns_none(system, user):
-        return None
-
-    with patch("app.core.config.settings.TAVILY_API_KEY", "dummy"):
-        with patch("app.agents.macro.httpx.AsyncClient", return_value=mock_client):
-            with patch("app.agents.macro.summarize", side_effect=summarize_returns_none):
-                state = make_state()
-                result = await macro_agent_node(state)
-
-    macro = result["macro_context"]
+    macro = res["macro_context"]
     assert macro["summary"] == "Inflation slowed …"
-    flag = result["flags"][-1]
+    flag = res["flags"][-1]
     assert isinstance(flag, DataFlag)
-    assert flag.source == "tavily"
+    assert flag.source == "nvidia_nim"
 
 
 @pytest.mark.asyncio
 async def test_macro_agent_logs_entry(caplog):
-    """Verify the logger emits an info record with correlation IDs at entry."""
-    state = make_state()
     with caplog.at_level(logging.INFO, logger="app.agents.macro"):
-        await macro_agent_node(state)
+        with patch("app.agents.macro.TavilyService") as MockService:
+            MockService.return_value.search = AsyncMock(return_value=_tavily_result())
+            await macro_agent_node(make_state())
     records = [r for r in caplog.records if r.name == "app.agents.macro"]
     assert len(records) >= 1
     rec = records[0]
-    assert rec.pipeline_run_id == state["pipeline_run_id"]
-    assert rec.morning_note_id == state["morning_note_id"]
-    assert rec.manager_id == state["manager_id"]
+    assert rec.pipeline_run_id == "run-1"
+    assert rec.morning_note_id == "note-1"
+    assert rec.manager_id == 1

--- a/tests/unit/test_tavily_service.py
+++ b/tests/unit/test_tavily_service.py
@@ -1,0 +1,111 @@
+import httpx
+from unittest.mock import patch, AsyncMock, MagicMock
+
+import pytest
+
+from app.services.tavily import (
+    TavilyArticle,
+    TavilyConfigError,
+    TavilyService,
+)
+from app.utils.flags import Severity
+
+
+def _mock_client(response_json):
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = response_json
+    mock_resp.raise_for_status = MagicMock()
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_resp
+    mock_client.__aenter__.return_value = mock_client
+    return mock_client
+
+
+def _mock_client_raises(exc):
+    mock_client = AsyncMock()
+    mock_client.post.side_effect = exc
+    mock_client.__aenter__.return_value = mock_client
+    return mock_client
+
+
+@pytest.mark.asyncio
+async def test_search_happy_path_returns_typed_articles():
+    payload = {"results": [{"title": "T", "content": "C", "url": "U"}]}
+    s = TavilyService(api_key="fake")
+    with patch("app.services.tavily.httpx.AsyncClient", return_value=_mock_client(payload)):
+        r = await s.search("macro news Brazil", ["bcb.gov.br"], max_results=5)
+    assert r.error is None
+    assert len(r.articles) == 1
+    assert isinstance(r.articles[0], TavilyArticle)
+    assert r.articles[0] == TavilyArticle(title="T", content="C", url="U")
+
+
+@pytest.mark.asyncio
+async def test_search_empty_results_returns_empty_no_error():
+    payload = {"results": []}
+    s = TavilyService(api_key="fake")
+    with patch("app.services.tavily.httpx.AsyncClient", return_value=_mock_client(payload)):
+        r = await s.search("slow news day", [])
+    assert r.articles == []
+    assert r.error is None
+
+
+@pytest.mark.asyncio
+async def test_search_http_failure_returns_warning():
+    s = TavilyService(api_key="fake")
+    with patch("app.services.tavily.httpx.AsyncClient", return_value=_mock_client_raises(httpx.ConnectError("network down"))):
+        r = await s.search("q", [])
+    assert r.articles == []
+    assert r.error is not None
+    assert r.error.source == "tavily"
+    assert r.error.severity == Severity.WARNING
+    assert "network down" in r.error.message
+
+
+@pytest.mark.asyncio
+async def test_search_null_title_or_content_returns_fatal_with_query():
+    payload = {"results": [{"title": None, "content": "good", "url": "u"}]}
+    s = TavilyService(api_key="fake")
+    with patch("app.services.tavily.httpx.AsyncClient", return_value=_mock_client(payload)):
+        r = await s.search("PETR4 news Brazil", [])
+    assert r.articles == []
+    assert r.error is not None
+    assert r.error.source == "tavily"
+    assert r.error.severity == Severity.FATAL
+    assert "PETR4 news Brazil" in r.error.message
+
+
+@pytest.mark.asyncio
+async def test_search_partial_null_articles_one_valid_one_invalid_returns_fatal():
+    payload = {"results": [
+        {"title": "valid", "content": "good", "url": "u"},
+        {"title": None, "content": None, "url": None},
+    ]}
+    s = TavilyService(api_key="fake")
+    with patch("app.services.tavily.httpx.AsyncClient", return_value=_mock_client(payload)):
+        r = await s.search("q", [])
+    assert r.error is not None
+    assert r.error.severity == Severity.FATAL
+
+
+def test_init_missing_key_raises_config_error():
+    with pytest.raises(TavilyConfigError) as exc_info:
+        TavilyService(api_key="")
+    assert "TAVILY_API_KEY missing or empty" in str(exc_info.value)
+
+
+def test_init_empty_key_from_settings_raises():
+    with patch("app.services.tavily.settings.TAVILY_API_KEY", ""):
+        with pytest.raises(TavilyConfigError):
+            TavilyService()
+
+
+def test_init_valid_key_does_not_read_settings():
+    s = TavilyService(api_key="explicit")
+    assert s.api_key == "explicit"
+    assert s.timeout == 10.0
+
+
+def test_init_explicit_timeout_overrides_default():
+    s = TavilyService(api_key="explicit", timeout=30.0)
+    assert s.timeout == 30.0


### PR DESCRIPTION
## What this PR does

- **Adds `app/services/tavily.py`** — a domain-scoped service module owning:
  - `TavilyError` hierarchy: `TavilyConfigError` (missing key — raised at construction), `TavilyRequestError` (HTTP, doc-only in v1), `TavilyParseError` (parse, doc-only in v1).
  - `TavilyArticle` frozen dataclass with `title: str | None`, `content: str | None`, `url: str`.
  - `TavilyResult` frozen dataclass with `articles: list[TavilyArticle]`, `error: DataFlag | None`.
  - `TavilyService.__init__(api_key: str, timeout: float = 10.0)` — raises `TavilyConfigError` on empty key.
  - `TavilyService.search(query: str) -> TavilyResult` — async HTTP via `httpx.AsyncClient`, parses results to typed articles, FATAL if any article has `title is None or content is None`, returns a WARNING `DataFlag` on `httpx` raise. Does NOT raise across the boundary — agents mutate state locally.
- **Rewrites `app/agents/macro.py`** — drops the inline `httpx.AsyncClient` flow + parse-block guard. Catches `TavilyConfigError` once at the node boundary (FATAL + return). Uses `result.error` (append + return) instead of inline try/except.
- **Rewrites `app/agents/company.py`** — same shape as macro. Fixes a real bug found by reading: `DataFlag(sources="tavily", ...)` (typo — would have raised `TypeError` on the `TavilyConfigError` catch path, crashing the node harder than the original failure on a real missing-key scenario).
- **Adds `tests/unit/test_tavily_service.py`** — 9 tests covering: happy path, empty `{"results": []}` (no flag), HTTP failure (WARNING), null title/content (FATAL with query in message via `!r`), partial-null articles (one valid + one invalid → FATAL), missing key raises `TavilyConfigError`, explicit key does NOT read `settings`, explicit timeout override honored.
- **Rewrites `tests/unit/test_macro_agent.py`** (5 tests) and `tests/unit/test_company_agent.py` (5 tests) — mocks now patch at the `TavilyService` boundary (`app.agents.macro.TavilyService` → `MagicMock` whose `.search` is `AsyncMock`). New `test_macro_agent_tavily_config_error` and `test_company_agent_tavily_service_error` exercise the construction-catch path the old tests never hit.
- **Adds commit `12ecb30` — fix(macro): correct `source=nvidia_nim` for LLM-None flag (#61 Part 1)** — the macro audit's mislabel was `source="tavily"` on the LLM-None branch; should have been the failing upstream (`nvidia_nim`).
- **Backports FATAL-parse rule to macro as a behavior change** (#61 Part 2 — intentionally NOT an in-place fix, superseded by the service extraction): before, Tavily returning `{"results": [{"title": null, ...}]}` silently set `macro_context=None` with no flag; after, a FATAL flag is emitted. Operators will now page on schema breaks where before they silently degraded — this is the #61 bug being fixed.

## What this PR does NOT do

- **No retry policy.** `TavilyRequestError` / `TavilyParseError` classes are kept in the hierarchy for future retry-policy discrimination but are documentation-only in v1 — `search()` builds `DataFlag` inline rather than instantiating them.
- **No rate limiting, no circuit breaker, no caching on `TavilyService`.** Out of scope for the dedup extraction.
- **`uv.lock` not staged** — carries OpenAI/httpx dep changes that belong to a separate standing decision (kept out of #09's commit scope per journal `16.md`; not introduced into #62 either).
- **No shared `ServiceError` base.** Domain-scoped like `PipelineError` per existing convention. YAGNI until a second service exists.

## How to verify

```bash
# All three gates green on the branch:
uv run ruff check .                    # full repo
uv run mypy app/services/tavily.py app/agents/macro.py app/agents/company.py
uv run pytest tests/ -v                # 35 passed, 12 skipped (DB/container-gated)

# Specifically the new + rewritten tests:
uv run pytest tests/unit/test_tavily_service.py tests/unit/test_macro_agent.py tests/unit/test_company_agent.py tests/unit/test_company_agent_stub.py tests/unit/test_macro_agent_stub.py -v
```

Implementation design doc: `.opencode/followups/extract-tavily-service.md` (110 lines, implemented as proposed with two divergences — see Decisions).

## Decisions worth flagging

- **Service boundary = `app/services/tavily.py`** (Option A placement). Matches the existing `PipelineError`-in-`app/api/errors.py` convention. Test for "does this class belong in utils/" — would a consumer of this class NOT already know about its producer? `TavilyConfigError`'s consumers all already import `app.services.tavily` → co-located.

- **Missing-key handling: raise at construction, catch once per pipeline run (Option C).** `TavilyService.__init__` raises `TavilyConfigError`; the agent node catches once, emits FATAL, sets empty state, returns. No per-agent duplication; no silent empty-result-on-construction. The failure is loud at the boundary.

- **HTTP and parse failures: returned as `TavilyResult.error: DataFlag | None`, never raised across the boundary.** Agents must mutate state (flag + set-empty + timestamp); the return-based contract keeps state mutation local to the agent. Raising would unwind through the agent without it touching `state["flags"]`.

- **Construction per-call inside the node function (Option B for placement), NOT module-level.** Module-level would import-time-crash when `TAVILY_API_KEY` is unset — breaking tests, CI (no `.env`), and hot reload, and re-introducing the `with patch("app.core.config.settings.TAVILY_API_KEY", "dummy"):` boilerplate we just eliminated.

- **Empty `{"results": []}` is VALID — no flag, `TavilyResult(articles=[], error=None)`.** Distinguishes "no matches" (Tavily honored the contract — operator not paged on slow news days) from "schema broke" (null fields in returned articles → FATAL).

- **FATAL message includes the query string via `!r`:** `f"Tavily returned articles with null title/content for query {query!r} - schema may have changed"`. The query is universally available at the service layer; ticker is agent-specific so it stays out. `!r` makes whitespace/hidden chars visible to the operator for manual re-run.

- **Layered test mocking:** agent tests mock at the service boundary (Option A — black-box); service tests mock at the `httpx` boundary (Option B — behavior-box). Each layer catches bugs the other can't see.

- **Four mock-fraud bugs found and fixed during the refactor** (all caught by reading or by the new service-layer tests, not by the existing agent-layer tests):
  1. `timenout=...` kwarg typo — invisible because mocks accept any kwarg.
  2. `all(... and ...)` vs `any(... or ...)` confusion on the FATAL check — would have mis-evaluated on real data.
  3. `AsyncMock(return_value=None)` set as `__aexit__.return_value` — silently swallowed exceptions because the mock is truthy (Python's `async with` suppresses on truthy `__aexit__` return). Led to `UnboundLocalError` on `data` because the `ConnectError` was swallowed and execution fell through. Fix: use literal `False` or remove the override entirely.
  4. `DataFlag(sources="tavily", ...)` typo in `company.py` catch path — would have crashed the very `TavilyConfigError` catch path with `TypeError`. Caught by reading, not by any existing test.

- **#61 Part 2 (parse-block guard backport to `macro.py` in-place) intentionally NOT done** — the #62 service extraction removes the need (service owns the guard now). Divergence from the follow-up doc's "do #61 in-place first, then extract" ordering; for Part 1 we respected the ordering, for Part 2 the rationale for not-duplicate-then-delete held.

- **Follow-up: audit codebase for the `AsyncMock(...) __aexit__.return_value = AsyncMock(...)` exception-suppression anti-pattern.** Mocked tests can ship silent exception-vacuums because mocks don't honor Python's truthy/falsy semantics on returned values the way real context managers do.

Closes #62
Closes #61