### PR TITLE
feat(issue-11): shared-state integration test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,27 @@ jobs:
           NVIDIA_BASE_URL: https://integrate.api.nvidia.com/v1
           NVIDIA_MODEL: openai/gpt-oss-20b
           NVIDIA_FALLBACK_MODEL: openai/gpt-oss-20b
+
+  integration-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: uv sync --group dev
+
+      - name: Run agent integration tests
+        run: uv run pytest tests/integration/test_agents.py -v
+        env:
+          DATABASE_URL: postgresql+asyncpg://placeholder@localhost:5432/placeholder
+          MIGRATION_DATABASE_URL: postgresql://placeholder@localhost:5432/placeholder
+          TAVILY_API_KEY: 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
+          NVIDIA_API_KEY: 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
+          NVIDIA_BASE_URL: https://integrate.api.nvidia.com/v1
+          NVIDIA_MODEL: openai/gpt-oss-20b
+          NVIDIA_FALLBACK_MODEL: openai/gpt-oss-20b

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,10 +2,8 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Generator
 import os
+import subprocess
 from pathlib import Path
-
-from alembic import command
-from alembic.config import Config
 
 import asyncpg
 import pytest
@@ -36,11 +34,14 @@ def pg_container() -> Generator[PostgresContainer, None, None]:
 @pytest.fixture(scope="session")
 def migrated_db_url(pg_container: PostgresContainer) -> Generator[str, None, None]:
     url = pg_container.get_connection_url(driver="asyncpg")
-    cfg = Config(str(Path("alembic.ini").resolve()))
     original_db_url = os.environ.get("DATABASE_URL")
     os.environ["DATABASE_URL"] = url
     try:
-        command.upgrade(cfg, "head")
+        subprocess.run(
+            ["alembic", "upgrade", "head"],
+            check=True,
+            cwd=str(Path(__file__).resolve().parent.parent),
+        )
         yield url
     finally:
         if original_db_url is None:
@@ -142,3 +143,4 @@ def rls_role(migrated_db_url: str) -> Generator[str, None, None]:
         yield f"postgresql+asyncpg://rls_test:rls_test_pwd@{admin_url.split('@', 1)[1]}"
     finally:
         asyncio.run(_teardown())
+        

--- a/tests/integration/test_agents.py
+++ b/tests/integration/test_agents.py
@@ -1,0 +1,63 @@
+import pytest
+from unittest.mock import patch, AsyncMock
+
+from app.agents.macro import macro_agent_node
+from app.agents.company import company_agent_node
+from app.agents.quant import quant_agent_node
+from app.graph.state import create_initial_state, DataFlag
+from app.services.tavily import TavilyResult
+from app.services.yfinance import YfinanceResult
+from app.utils.flags import Severity
+
+
+def make_state():
+    return create_initial_state(
+        manager_id=1,
+        company_ticker="PETR4",
+        pipeline_run_id="run-1",
+        morning_note_id="note-1"
+    )
+
+
+@pytest.mark.asyncio
+async def test_pipeline_all_agents_fail_shares_state():
+    """Sequential A1: macro -> company -> quant, all mocked to fail,
+    against one shared AgentState. Flags accumulate; freshness keys
+    land per agent; state stays internally consistent."""
+    state = make_state()
+
+    err = DataFlag(source="tavily", severity=Severity.WARNING, message="Tavily 500")
+    with patch("app.agents.macro.TavilyService") as M, \
+         patch("app.agents.macro.summarize", new=AsyncMock(return_value="")):
+        M.return_value.search = AsyncMock(return_value=TavilyResult(articles=[], error=err))
+        state = await macro_agent_node(state)
+    assert state["macro_context"] is None
+    assert len(state["flags"]) == 1
+    assert "macro" in state["data_freshness"]
+
+    with patch("app.agents.company.TavilyService") as C, \
+         patch("app.agents.company.summarize", new=AsyncMock(return_value="")):
+        C.return_value.search = AsyncMock(return_value=TavilyResult(articles=[], error=err))
+        state = await company_agent_node(state)
+    assert state["company_events"] == []
+    assert len(state["flags"]) == 2
+    assert "company" in state["data_freshness"]
+
+    stale_err = DataFlag(
+        source="yfinance",
+        severity=Severity.FATAL,
+        message="Yfinance data 'PETR4' is 48.0h old (max 24h)"
+    )
+    with patch("app.agents.quant.YfinanceService") as Q:
+        Q.return_value.search = AsyncMock(return_value=YfinanceResult(metrics=None, error=stale_err))
+        state = await quant_agent_node(state)
+    assert state["quant_metrics"] is None
+    assert state["flags"][-1].source == "yfinance"
+    assert "48" in state["flags"][-1].message
+    assert state["data_freshness"]["quant"] is not None
+
+    assert len(state["flags"]) == 3
+    assert set(state["data_freshness"]) == {"macro", "company", "quant"}
+    assert state["manager_id"] == 1
+    assert state["company_ticker"] == "PETR4"
+    


### PR DESCRIPTION
## What this PR does
- Adds `tests/integration/test_agents.py` with one integration test: `test_pipeline_all_agents_fail_shares_state`
- The test exercises Option A1: three agents (MacroAgent → CompanyAgent → QuantAgent) sequentially against a shared `AgentState`, each mocked to fail
- Verifies cross-agent invariants: 3 DataFlags accumulate, 3 freshness keys land (`macro`, `company`, `quant`), identity fields (`manager_id`, `company_ticker`) preserved
- Satisfies all five issue criteria in a single test (per Option A discussed in issue #11)

## What this PR does NOT do
- Does NOT test LangGraph parallel/reducer behavior — that is tracked in followup issue #73 (to be replaced when #14 implements `Annotated` reducers)
- Does NOT add DB fixtures or Docker requirements — pure mock test, fast and Docker-agnostic
- Does NOT modify agent implementations (`app/agents/macro.py`, `company.py`, `quant.py`) — their contracts stay as-is
- Does NOT guarantee all integration tests pass in CI — our test is scope-locked; the full suite remains issue #05d

## How to verify
```bash
uv run pytest tests/integration/test_agents.py -v
# Expected: 1 passed in ~2.5s

# CI also runs this job via the new `integration-tests` workflow job
# Manual cross-check: 3 flags in state["flags"], 3 keys in state["data_freshness"],
# state["manager_id"] == 1, state["company_ticker"] == "PETR4"
```

## Decisions worth flagging
- **A1 vs A2**: Option A1 chosen to match issue criteria directly; Option A2 (LangGraph reducer simulation) filed as issue #73 for when #14 implements `Annotated` reducers. Risk: A1 tests sequential accumulation, which is the only thing unit tests don't already cover.
- **conftest Option X fix**: `subprocess.run(["alembic", "upgrade", "head"], ...)` replaces the shadowed `from alembic import command` import. Mitigation: alembic CLI binary is installed by `pip install alembic` and on GHA ubuntu-latest; fixture fails fast if missing rather than silently producing wrong URLs.
- **Test scope**: Single test body covers all five issue criteria rather than three separate test functions; this was a deliberate trade-off so accumulation (the integration-invariants part) is tested rather than duplicated. If a traditional "3 testes" format is preferred, #73 tracks the refactor.
- **API keys in CI env**: Mirrors existing `unit-tests` job's hardcoded `TAVILY_API_KEY` / `NVIDIA_API_KEY`. Our test patches both services out (mock at `search()` boundary), so real calls never execute; keys are carry-over from prior CI config, not newly introduced.
- **Title format**: `feat(issue-11): shared-state integration test` follows conventional commits; issue-11 scope locked.
