### PR TITLE
feat(quant): Closes #68 — add market_time (data-time) to QuantOutput

### DIFF
--- a/app/agents/quant.py
+++ b/app/agents/quant.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 async def quant_agent_node(state: AgentState) -> AgentState:
     """Pull financial metrics via YfinanceService, build a QuantOutput, and update
-    AgentState in-place. Failures append a DataFlag and return with quant_metrics=None - 
+    AgentState in-place. Failures append a DataFlag and return with quant_metrics=None -
     never raises.
     """
     logger.info(
@@ -19,19 +19,15 @@ async def quant_agent_node(state: AgentState) -> AgentState:
         extra={
             "pipeline_run_id": state["pipeline_run_id"],
             "morning_note_id": state["morning_note_id"],
-            "manager_id": state["manager_id"]
-        }
+            "manager_id": state["manager_id"],
+        },
     )
 
     try:
         yfinance_service = YfinanceService(ticker=state["company_ticker"])
     except YfinanceError as exc:
         state["flags"].append(
-            DataFlag(
-                source="yfinance",
-                severity=Severity.FATAL,
-                message=str(exc)
-            )
+            DataFlag(source="yfinance", severity=Severity.FATAL, message=str(exc))
         )
         state["quant_metrics"] = None
         state["data_freshness"]["quant"] = datetime.now(UTC)
@@ -52,9 +48,14 @@ async def quant_agent_node(state: AgentState) -> AgentState:
         "p_vpa": result.metrics.p_vpa,
         "dividend_yield": result.metrics.dividend_yield,
         "dev_ibov": result.metrics.dev_ibov,
-        "fetched_at": result.metrics.fetched_at
+        "fetched_at": result.metrics.fetched_at,
+        "market_time": result.metrics.market_time,
     }
 
     state["quant_metrics"] = quant_metrics
-    state["data_freshness"]["quant"] = datetime.now(UTC)
+    state["data_freshness"]["quant"] = (
+        result.metrics.market_time
+        if result.metrics.market_time is not None
+        else datetime.now(UTC)
+    )
     return state

--- a/app/graph/state.py
+++ b/app/graph/state.py
@@ -25,6 +25,7 @@ class QuantOutput(TypedDict, total=False):
     dividend_yield: float | None
     dev_ibov: float | None
     fetched_at: str
+    market_time: datetime | None
 
 
 class RiskFlag(TypedDict, total=False):

--- a/app/services/yfinance.py
+++ b/app/services/yfinance.py
@@ -21,6 +21,7 @@ class QuoteMetrics:
     dividend_yield: float | None
     dev_ibov: float | None
     fetched_at: str
+    market_time: datetime | None
 
 
 @dataclass(frozen=True)
@@ -61,13 +62,17 @@ class YfinanceService:
                 )
             )
 
-        market_time = info.get("regularMarketTime")
-        if market_time is not None:
+        market_time_raw = info.get("regularMarketTime")
+        market_time_dt: datetime | None = None
+        if market_time_raw is not None:
             try:
-                data_age_hours = (datetime.now(UTC).timestamp() - float(market_time)) / 3600
+                market_time_dt = datetime.fromtimestamp(float(market_time_raw), UTC)
             except (TypeError, ValueError):
-                data_age_hours = None
-            if data_age_hours is not None and data_age_hours > self.max_data_age_hours:
+                market_time_dt = None
+                
+        if market_time_dt is not None:
+            data_age_hours = (datetime.now(UTC).timestamp() - market_time_dt.timestamp()) / 3600
+            if data_age_hours > self.max_data_age_hours:
                 return YfinanceResult(
                     metrics=None,
                     error=DataFlag(
@@ -130,7 +135,8 @@ class YfinanceService:
             p_vpa=info.get("priceToBook"),
             dividend_yield=info.get("dividendYield"),
             dev_ibov=dev_ibov,
-            fetched_at=datetime.now(UTC).isoformat()
+            fetched_at=datetime.now(UTC).isoformat(),
+            market_time=market_time_dt,
         )
 
         return YfinanceResult(metrics=metrics, error=None)

--- a/tests/unit/test_quant_agent.py
+++ b/tests/unit/test_quant_agent.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime
+from datetime import UTC, datetime
 from unittest.mock import patch, AsyncMock
 
 import pytest 
@@ -26,7 +26,8 @@ def _metrics(**overrides):
         "p_vpa": 1.3,
         "dividend_yield": 0.04,
         "dev_ibov": 0.08,
-        "fetched_at": datetime.now().isoformat()
+        "fetched_at": datetime.now().isoformat(),
+        "market_time": None
     }
     base.update(overrides)
     return QuoteMetrics(**base)
@@ -104,4 +105,25 @@ async def test_quant_agent_logs_entry(caplog):
         assert records[0].pipeline_run_id == "run-1"
         assert records[0].morning_note_id == "note-1"
         assert records[0].manager_id == 1
-        
+
+
+@pytest.mark.asyncio
+async def test_quant_agent_market_time_populated_from_metrics():
+    market_time = datetime(2026, 8, 14, 13, 30, tzinfo=UTC)
+    result = YfinanceResult(metrics=_metrics(market_time=market_time), error=None)
+    with patch("app.agents.quant.YfinanceService") as MockSvc:
+        MockSvc.return_value.search = AsyncMock(return_value=result)
+        res = await quant_agent_node(make_state())
+
+    assert res["quant_metrics"]["market_time"] == market_time
+
+
+@pytest.mark.asyncio
+async def test_quant_agent_data_freshness_uses_data_time_when_present():
+    market_time = datetime(2026, 8, 14, 13, 30, tzinfo=UTC)
+    result = YfinanceResult(metrics=_metrics(market_time=market_time), error=None)
+    with patch("app.agents.quant.YfinanceService") as MockSvc:
+        MockSvc.return_value.search = AsyncMock(return_value=result)
+        res = await quant_agent_node(make_state())
+
+    assert res["data_freshness"]["quant"] == market_time

--- a/tests/unit/test_yfinance_service.py
+++ b/tests/unit/test_yfinance_service.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import time
 from unittest.mock import patch, MagicMock
 import pandas as pd
@@ -59,6 +60,8 @@ async def test_search_happy_path_returns_typed_metrics():
     assert result.metrics.dividend_yield == 0.04
     assert abs(result.metrics.dev_ibov - 0.08) < 1e-9
     assert result.metrics.fetched_at
+    assert result.metrics.market_time is not None
+    assert isinstance(result.metrics.market_time, datetime)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What this PR does

- Adds `market_time: datetime | None` field to `QuantOutput` (`app/graph/state.py:28`) — captures when the market last produced this data (yfinance's `regularMarketTime`), distinct from the existing `fetched_at: str` (when we queried yfinance).
- Adds `market_time: datetime | None` field to `QuoteMetrics` (`app/services/yfinance.py:24`) — the producer-side type that crosses the yfinance service boundary.
- Refactors `YfinanceService.search()` (`app/services/yfinance.py:65-71`) to parse `regularMarketTime` (Unix epoch) into a typed `datetime` once via `datetime.fromtimestamp(float(raw), UTC)`, re-used by both the freshness gate and the `QuoteMetrics` constructor. Eliminates a duplicated `float(...)` parse and surfaces the **latent silently-bypassed-freshness-gate bug** — parse failure now produces `market_time_dt = None` which skips the gate explicitly, rather than the old `except: data_age_hours = None` swallow that fell through silently.
- Wires `quant_agent_node` (`app/agents/quant.py:56,59-64`) to copy `result.metrics.market_time` into `quant_metrics["market_time"]` and switch `state["data_freshness"]["quant"]` from fetch-time (`datetime.now(UTC)`) to data-time when `market_time is not None`, falling back to fetch-time (α-behavior from issue #10) when it is.
- Adds two unit tests in `tests/unit/test_quant_agent.py`:
  - `test_quant_agent_market_time_populated_from_metrics` — asserts `quant_metrics["market_time"]` carries through from `QuoteMetrics`.
  - `test_quant_agent_data_freshness_uses_data_time_when_present` — asserts `data_freshness["quant"]` equals the data-time, not a fresh `datetime.now(UTC)`.
- Updates `_metrics()` helper in `test_quant_agent.py:22-32` to default `market_time=None` so all existing tests still construct valid `QuoteMetrics` instances.
- Adds two assertions in `test_yfinance_service.py::test_search_happy_path_returns_typed_metrics` that `result.metrics.market_time` is non-None and a `datetime` instance.

## What this PR does NOT do

- Does NOT implement RiskAgent (issue #12) — this PR is the **design-phase prerequisite** decision referenced in #68: "does RiskAgent need `market_time`?". The decision was YES — β1 is implemented here, clearing RiskAgent #12's design phase to begin.
- Does NOT coordinate with issue #65 (multi-horizon `dev_ibov`) — both touch `QuantOutput` schema; #65 remains open and should be implemented separately to avoid double schema churn. Not blocking either direction.
- Does NOT change `fetched_at: str` to a `datetime` — `fetched_at` stays a serializable ISO-8601 string for display/log/storage consumers (no arithmetic consumer); `market_time` is the arithmetic-typed sibling for RiskAgent's time-correlation work.
- Does NOT touch `MacroOutput` or `CompanyEvent` freshness fields — they remain on the macro/company agents' fetch-time pattern (α); this PR is scoped to `QuantOutput` only.
- Does NOT add an integration test exercising `market_time` end-to-end through the LangGraph pipeline — that belongs with RiskAgent #12's integration suite when the consumer exists.

## How to verify

```bash
# Type-check the three touched source files
uv run mypy app/graph/state.py app/services/yfinance.py app/agents/quant.py

# Lint
uv run ruff check app/graph/state.py app/services/yfinance.py app/agents/quant.py tests/unit/test_quant_agent.py tests/unit/test_yfinance_service.py

# New + existing unit tests must pass
uv run pytest tests/unit/test_quant_agent.py tests/unit/test_yfinance_service.py -v

# Full unit suite (sanity)
uv run pytest tests/unit/ -q
```

Expected: mypy clean, ruff clean, 44 unit tests passed (the two new tests are `test_quant_agent_market_time_populated_from_metrics` and `test_quant_agent_data_freshness_uses_data_time_when_present`).

## Decisions worth flagging

### Option B — `market_time: datetime | None` (deviates from issue spec)

Issue #68's "Schema change" section specified `market_time: datetime` (no `| None`). We deviated to `datetime | None` on both `QuantOutput` and `QuoteMetrics` for **consistency with the `float | None` siblings** (`pl`, `ev_ebitda`, `p_vpa`, `dividend_yield`, `dev_ibov`) — all of which are always set on the dict, even when their value is `None`. With `total=False`, the alternative ("Option A") would have signaled absence by **omitting the key**, which is inconsistent with how every other quant metric behaves. This means `quant_metrics["market_time"]` is always present post-QuantAgent; readers can `.get("market_time")` and reliably get `datetime | None` back.

### Rename inside `YfinanceService.search()` is load-bearing

The original local `market_time` (raw Unix epoch, `int`/`str`) was renamed `market_time_raw`, and the parsed value is `market_time_dt: datetime | None`. The two meanings (raw epoch vs typed datetime) were silently aliased under one name in #10's Chunk 5; the rename makes the type flow visible at every readsite and prevents future devs from calling `float()` on the typed value.

### `datetime.fromtimestamp(ts, UTC)` not `datetime.fromtimestamp(ts)`

The naive form returns local time; comparing a local-typed `market_time` against a UTC-typed news timestamp inside RiskAgent would silently offset by hours. Explicit `tz=UTC` is the only safe form here.

### Freshness-gate bypass made explicit

Pre-PR: `try: float(market_time) except (TypeError, ValueError): data_age_hours = None` — parse failure fell through past the freshness gate without flag. Post-PR: parse failure sets `market_time_dt = None` which causes the `if market_time_dt is not None:` guard to skip the freshness check explicitly. Same runtime behavior, but the reason is now at the variable level instead of buried in an `except` clause. Not a behavior change — surfacing this so a reviewer doesn't mistake it for a regression.

### `docs/` is gitignored

`docs/finagent-CLAUDE.md` (including the new Rule 6 "Secrets handling" added in this session) and `docs/journal/new/1_week/19.md` (the secret-scrub incident record) are **not** carried by this PR — `.gitignore:12` excludes `docs/`. These are local-only files today. A separate follow-up is needed to decide whether to untrack `docs/` so journal durability works across machines. Not in scope for #68.
