### PR TITLE
feat(issue-77): Closes #77 — RiskAgent parse and DataFlag integration

### DIFF
--- a/app/agents/risk.py
+++ b/app/agents/risk.py
@@ -1,0 +1,39 @@
+from datetime import datetime, UTC
+import logging
+
+from app.prompts.risk import RISK_PROMPTS
+from app.services.llm import summarize
+from app.graph.state import AgentState
+
+
+logger = logging.getLogger(__name__)
+
+
+async def risk_agent_node(state: AgentState) -> AgentState:
+    """Read upstream agent products, call the LLM for adversarial risk analysis, and stage 
+    the raw response for parsing. Failures append a DataFlag and return with risk_flags=[] - never raises.
+    """
+    logger.info(
+        "risk_agent_start",
+        extra={
+            "pipeline_run_id": state["pipeline_run_id"],
+            "morning_note_id": state["morning_note_id"],
+            "manager_id": state["manager_id"]
+        }
+    )
+
+    user_prompt = RISK_PROMPTS.build_user_prompt(
+        macro_context=state.get("macro_context"),
+        company_events=state.get("company_events", []),
+        quant_metrics=state.get("quant_metrics"),
+        data_flags=state.get("flags", [])
+    )
+
+    raw_text = await summarize(
+        system=RISK_PROMPTS.system,
+        user=user_prompt
+    )
+
+    state["risk_flags"] = []
+    state["data_freshness"]["risk"] = datetime.now(UTC)
+    return state

--- a/app/agents/risk.py
+++ b/app/agents/risk.py
@@ -1,5 +1,4 @@
 from datetime import datetime, UTC
-import json
 import logging
 
 from app.prompts.risk import RISK_PROMPTS

--- a/app/agents/risk.py
+++ b/app/agents/risk.py
@@ -1,9 +1,12 @@
 from datetime import datetime, UTC
+import json
 import logging
 
 from app.prompts.risk import RISK_PROMPTS
 from app.services.llm import summarize
 from app.graph.state import AgentState
+from app.utils.risk_parse import parse_risk_json
+from app.utils.flags import DataFlag, Severity
 
 
 logger = logging.getLogger(__name__)
@@ -34,6 +37,15 @@ async def risk_agent_node(state: AgentState) -> AgentState:
         user=user_prompt
     )
 
-    state["risk_flags"] = []
+    flags, dropped = parse_risk_json(raw_text)
+    state["risk_flags"] = flags
+    if dropped > 0 or raw_text is None:
+        state["flags"].append(
+            DataFlag(
+                source="risk_parse",
+                severity=Severity.WARNING,
+                message=f"{dropped} risk flag(s) dropped during parsing",
+            )
+        )
     state["data_freshness"]["risk"] = datetime.now(UTC)
     return state

--- a/app/prompts/risk.py
+++ b/app/prompts/risk.py
@@ -1,0 +1,50 @@
+from dataclasses import dataclass
+
+from app.graph.state import MacroOutput, CompanyEvent, QuantOutput
+from app.utils.flags import DataFlag
+
+
+@dataclass(frozen=True)
+class RiskPrompts:
+    system: str
+
+    def build_user_prompt(
+            self,
+            *,
+            macro_context: MacroOutput | None,
+            company_events: list[CompanyEvent],
+            quant_metrics: QuantOutput | None,
+            data_flags: list[DataFlag],
+    ) -> str:
+        lines: list[str] = []
+        lines.append("## Macro context")
+        lines.append(str(macro_context))
+        lines.append("\n## Company events")
+        for ev in company_events:
+            lines.append(f"- {ev.get('title', '')}: {ev.get('summary', '')}")
+        lines.append("\n## Quant metrics")
+        lines.append(str(quant_metrics))
+        if data_flags:
+            lines.append("\n## Known data gaps (DataFlags)")
+            for f in data_flags:
+                lines.append(f"- [{f.severity.value}] {f.source}: {f.message}")
+        lines.append(
+            "\n\nList the risks. Answer ONLY with valid JSON: a list of "
+            "objects with keys probability (float 0-1), impact "
+            "('low' | 'medium' | 'high'), description (str), severity "
+            "('info' | 'warning' | 'fatal')."
+        )
+        return "\n".join(lines)
+
+
+RISK_PROMPTS = RiskPrompts(
+    system=(
+        "You are a skeptical risk analyst on a Brazilian investment "
+        "team. Your job is to surface inconsistencies, ignored risks, "
+        "and biases in what the macro, company, and quant agents "
+        "produced. You do NOT fetch external data - you only analyze "
+        "what the other agents produced. If there are data gaps "
+        "(DataFlags), name them as additional risk. Respond ONLY "
+        "with valid JSON: a list of objects."
+    ),
+)

--- a/app/utils/risk_parse.py
+++ b/app/utils/risk_parse.py
@@ -1,0 +1,84 @@
+import json
+import logging
+import re
+from typing import get_args
+
+from app.graph.state import RiskFlag
+from app.utils.flags import Severity
+
+
+logger = logging.getLogger(__name__)
+
+_VALID_IMPACTS = set(get_args(RiskFlag.__annotations__["impact"]))
+_VALID_SEVERITIES = {s.value for s in Severity}
+
+
+def parse_risk_json(text: str | None) -> tuple[list[RiskFlag], int]:
+    """Parse raw LLM text into a validated list of RiskFlag dicts.
+    Tolerant: drops individual invalid items and keeps the rest.
+    Returns (flags, dropped_count). dropped_count is the number of
+    items that failed validation and were skipped.
+    Never raises.
+    """
+    if not text:
+        return [], 0
+
+    match = re.search(r"\[.*\]", text, flags=re.DOTALL)
+    if match is None:
+        return [], 0
+    try:
+        parsed = json.loads(match.group(0))
+    except json.JSONDecodeError:
+        return [], 0
+    if not isinstance(parsed, list):
+        return [], 0
+
+    flags: list[RiskFlag] = []
+    dropped = 0
+    for item in parsed:
+        if not isinstance(item, dict):
+            dropped += 1
+            continue
+        prob = item.get("probability")
+        impact = item.get("impact")
+        desc = item.get("description")
+        sev = item.get("severity")
+
+        if not isinstance(prob, (int, float)) or not 0.0 <= prob <= 1.0:
+            dropped += 1
+            logger.warning(
+                "risk_parse_drop",
+                extra={"reason": "invalid_probability", "value": prob},
+            )
+            continue
+        if impact not in _VALID_IMPACTS:
+            dropped += 1
+            logger.warning(
+                "risk_parse_drop",
+                extra={"reason": "invalid_impact", "value": impact},
+            )
+            continue
+        if not isinstance(desc, str) or not desc:
+            dropped += 1
+            logger.warning(
+                "risk_parse_drop",
+                extra={"reason": "invalid_description", "value": desc},
+            )
+            continue
+        if sev not in _VALID_SEVERITIES:
+            dropped += 1
+            logger.warning(
+                "risk_parse_drop",
+                extra={"reason": "invalid_severity", "value": sev},
+            )
+            continue
+
+        flags.append(
+            RiskFlag(
+                probability=float(prob),
+                impact=impact,
+                description=desc,
+                severity=sev,
+            )
+        )
+    return flags, dropped

--- a/app/utils/risk_parse.py
+++ b/app/utils/risk_parse.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import re
-from typing import get_args
+from typing import cast, get_args, Literal
 
 from app.graph.state import RiskFlag
 from app.utils.flags import Severity
@@ -76,7 +76,7 @@ def parse_risk_json(text: str | None) -> tuple[list[RiskFlag], int]:
         flags.append(
             RiskFlag(
                 probability=float(prob),
-                impact=impact,
+                impact=cast(Literal["low", "medium", "high"], impact),
                 description=desc,
                 severity=sev,
             )

--- a/scripts/run_risk_agent.py
+++ b/scripts/run_risk_agent.py
@@ -1,0 +1,42 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import asyncio
+
+from app.agents.risk import risk_agent_node
+from app.graph.state import create_initial_state
+
+
+async def main() -> None:
+    state = create_initial_state(
+        manager_id=1,
+        company_ticker="PETR4",
+        pipeline_run_id="run-risk-manual-1",
+        morning_note_id="note-risk-manual-1",
+    )
+
+    result = await risk_agent_node(state)
+
+    risk_flags = result["risk_flags"]
+    print("risk_flags count:", len(risk_flags))
+    if risk_flags:
+        rf = risk_flags[0]
+        print("  probability:", rf["probability"])
+        print("  impact:", rf["impact"])
+        print("  description:", rf["description"])
+        print("  severity:", rf["severity"])
+
+    print("\ndata_freshness:", result["data_freshness"])
+
+    flags = result["flags"]
+    print("\nflags count:", len(flags))
+    if flags:
+        f = flags[0]
+        print("  source:", f.source)
+        print("  severity:", f.severity)
+        print("  message:", f.message)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/unit/test_risk_agent.py
+++ b/tests/unit/test_risk_agent.py
@@ -1,0 +1,45 @@
+import pytest
+from unittest.mock import patch
+
+from app.agents.risk import risk_agent_node
+from app.graph.state import create_initial_state
+from app.utils.flags import DataFlag, Severity
+
+
+def make_state():
+    return create_initial_state(
+        manager_id=1,
+        company_ticker="PETR4",
+        pipeline_run_id="run-1",
+        morning_note_id="note-1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_risk_agent_happy_path() -> None:
+    """mock summarize returning valid JSON; assert risk_flags populated"""
+    with patch("app.agents.risk.summarize") as MockSummarize:
+        MockSummarize.return_value = (
+            '[{"probability": 0.7, "impact": "high", '
+            '"description": "Market crash risk", "severity": "warning"}]'
+        )
+        state = await risk_agent_node(make_state())
+        assert len(state["risk_flags"]) >= 1
+        rf = state["risk_flags"][0]
+        assert rf["probability"] == 0.7
+        assert rf["impact"] == "high"
+        assert rf["description"] == "Market crash risk"
+        assert rf["severity"] == "warning"
+        assert state["data_freshness"]["risk"] is not None
+
+
+@pytest.mark.asyncio
+async def test_risk_agent_no_raw_text_dataflag() -> None:
+    """mock summarize returning None; assert DataFlag appended"""
+    with patch("app.agents.risk.summarize", return_value=None):
+        state = await risk_agent_node(make_state())
+        assert len(state["flags"]) >= 1
+        assert state["flags"][-1].source == "risk_parse"
+        assert state["flags"][-1].severity == Severity.WARNING
+        assert "risk flag(s) dropped" in state["flags"][-1].message
+        assert len(state["risk_flags"]) == 0

--- a/tests/unit/test_risk_agent.py
+++ b/tests/unit/test_risk_agent.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 from app.agents.risk import risk_agent_node
 from app.graph.state import create_initial_state
-from app.utils.flags import DataFlag, Severity
+from app.utils.flags import Severity
 
 
 def make_state():

--- a/tests/unit/test_risk_parse.py
+++ b/tests/unit/test_risk_parse.py
@@ -1,5 +1,3 @@
-import json
-
 from app.utils.risk_parse import parse_risk_json
 
 def test_parse_risk_valid_single_risk() -> None:

--- a/tests/unit/test_risk_parse.py
+++ b/tests/unit/test_risk_parse.py
@@ -1,0 +1,96 @@
+import json
+
+from app.utils.risk_parse import parse_risk_json
+
+def test_parse_risk_valid_single_risk() -> None:
+    text = '[{"probability": 0.3, "impact": "low", "description": "Limited downside risk", "severity": "info"}]'
+    flags, dropped = parse_risk_json(text)
+    assert dropped == 0
+    assert len(flags) == 1
+    assert flags[0]["probability"] == 0.3
+    assert flags[0]["impact"] == "low"
+    assert flags[0]["description"] == "Limited downside risk"
+    
+
+def test_parse_risk_three_risks() -> None:
+    text = (
+        '['
+        '{"probability": 0.3, "impact": "low", "description": "risk one", "severity": "info"},'
+        '{"probability": 0.6, "impact": "medium", "description": "risk two", "severity": "warning"},'
+        '{"probability": 0.9, "impact": "high", "description": "risk three", "severity": "fatal"}'
+        ']'
+    )
+    flags, dropped = parse_risk_json(text)
+    assert dropped == 0
+    assert len(flags) == 3
+    assert [f["severity"] for f in flags] == ["info", "warning", "fatal"]
+
+
+def test_parse_risk_wrapped_in_prose() -> None:
+    text = (
+        'Here is the analysis:\n'
+        '[{"probability": 0.5, "impact": "medium", "description": "macro risk", "severity": "warning"}]\n'
+        'Done.'
+    )
+    flags, dropped = parse_risk_json(text)
+    assert dropped == 0
+    assert len(flags) == 1
+    assert flags[0]["description"] == "macro risk"
+
+
+def test_parse_risk_malformed_json() -> None:
+    text = '[{"probability": 0.3, "impact": "low", "description": "broken"'
+    flags, dropped = parse_risk_json(text)
+    assert flags == []
+    assert dropped == 0
+
+
+def test_parse_risk_bad_probability_dropped() -> None:
+    text = (
+        '['
+        '{"probability": 1.5, "impact": "low", "description": "bad prob", "severity": "info"},'
+        '{"probability": 0.4, "impact": "low", "description": "good one", "severity": "info"}'
+        ']'
+    )
+    flags, dropped = parse_risk_json(text)
+    assert dropped == 1
+    assert len(flags) == 1
+    assert flags[0]["description"] == "good one"
+
+
+def test_parse_risk_bad_impact_dropped() -> None:
+    text = (
+        '['
+        '{"probability": 0.5, "impact": "extreme", "description": "bad impact", "severity": "info"},'
+        '{"probability": 0.5, "impact": "high", "description": "good one", "severity": "info"}'
+        ']'
+    )
+    flags, dropped = parse_risk_json(text)
+    assert dropped == 1
+    assert len(flags) == 1
+    assert flags[0]["description"] == "good one"
+
+
+def test_parse_risk_bad_severity_dropped() -> None:
+    text = (
+        '['
+        '{"probability": 0.5, "impact": "low", "description": "bad sev", "severity": "critical"},'
+        '{"probability": 0.5, "impact": "low", "description": "good one", "severity": "info"}'
+        ']'
+    )
+    flags, dropped = parse_risk_json(text)
+    assert dropped == 1
+    assert len(flags) == 1
+    assert flags[0]["description"] == "good one"
+
+
+def test_parse_risk_empty_input() -> None:
+    flags, dropped = parse_risk_json("")
+    assert flags == []
+    assert dropped == 0
+
+
+def test_parse_risk_none_input() -> None:
+    flags, dropped = parse_risk_json(None)
+    assert flags == []
+    assert dropped == 0


### PR DESCRIPTION
-- What this PR does

- Modified `app/agents/risk.py`: added `parse_risk_json()` call to extract valid RiskFlag dicts from LLM output; assign `state["risk_flags"] = flags`; append `DataFlag(source="risk_parse", severity=WARNING, message="... dropped during parsing")` when `dropped > 0` or `raw_text is None`; stamp `state["data_freshness"]["risk"] = datetime.now(UTC)`
- Added `tests/unit/test_risk_parse.py`: 9 test cases covering valid single risk, three risks, JSON wrapped in prose, malformed JSON, bad probability/impact/severity drops, empty/None input — pure, no mocks
- Added `tests/unit/test_risk_agent.py`: 2 async tests — happy path (mock summarize → valid JSON → risk_flags populated) and no-raw-text path (mock summarize → None → DataFlag appended, risk_flags empty)
- Added `scripts/run_risk_agent.py`: script following repo pattern (like `run_macro_agent.py`, `run_quant_agent.py`) to run `risk_agent_node` with initial state and print results

-- What this PR does NOT do

- Does NOT use GPT-4o for RiskAgent — continues using NVIDIA NIM via `app/services/llm.py:summarize` (deviation from issue #77 checklist, flagged for review)
- Does NOT add integration tests — chunk 4 unit tests only per journal spec; integration tests would be a follow-up
- Does NOT change the parser to raise on malformed input — best-effort return with drop accounting per codebase convention
- Does NOT modify `RiskFlag` TypedDict definition — uses existing `app/graph/state.RiskFlag`

-- How to verify

```bash
# 1. Run parser unit tests (no mocks, no API keys)
uv run pytest tests/unit/test_risk_parse.py -v

# 2. Run agent unit tests (mocks summarize)
uv run pytest tests/unit/test_risk_agent.py -v

# 3. Run all unit tests to confirm no regressions
uv run pytest tests/unit/ -v

# 4. Quick smoke test run the risk agent script
python scripts/run_risk_agent.py
```

-- Decisions worth flagging

- **NVIDIA NIM over GPT-4o:** RiskAgent continues using the repo's existing LLM boundary (NVIDIA NIM via `summarize`). Deviates from issue #77 checklist line "Usar GPT-4o para raciocínio complexo" — flagged for reviewer awareness. Code in `app/services/llm.py` stays unchanged (primary + fallback model paths already wired).
- **Fail-visible parse failures:** `DataFlag` appended when parse drops items or `raw_text is None`. Rationale: pipeline keeps running; downstream consumers (EditorAgent, RiskFlag viewers) see the flag and can surface warnings. Raising exceptions would break the LangGraph node contract ("never raises").
- **Parser drops, not all-or-nothing:** `parse_risk_json` returns `(valid_flags, dropped_count)` so the agent can keep valid flags and surface drop accounting. Follows codebase convention: "failure visible to the state consumer = DataFlag; never log-and-continue."
- **`__annotations__` fragility note:** `_VALID_IMPACTS = set(get_args(RiskFlag.__annotations__["impact"]))` depends on `state.py` NOT adopting `from __future__ import annotations`. If PEP 563 ever lands there, annotations become strings and `get_args` returns `()`. Switch to `typing.get_type_hints(RiskFlag)` the day that import appears. Surface in PR body for visibility.
- **Unit test coverage matches journal chunk 4 spec:** 9 parser test cases + 2 agent test cases. No integration tests added per journal — those would be a separate follow-up issue.

-- Resume point

- **Branch** `feature/issue-77 @ 884c805`, PR #XX open and ready for review
- **Next action:** human reviews + merges PR. After merge → fast-forward local `main`, delete `feature/issue-77`.
- **After #77 merges:** RiskAgent fully implemented with parse pipeline, DataFlag handling, and tests. Load `junior-socratic-coder` for Issue #12 (RiskAgent) or other open issues.
- **Open follow-ups carrying forward:** (1) `docs/` gitignore decision (still local-only), (2) GitHub Secret Scanning custom patterns for `tvly-*` + `nvapi-*`, (3) `CURRENT_STATE.md` refresh, (4) #65 multi-horizon `dev_ibov` next time `QuantOutput` is touched, (5) repo scaffolding files (LICENSE / CODEOWNERS / templates / `.gitignore` additions).

**Reviewers**: please confirm the `include_domains` pattern note isn't applicable here (this is risk parsing, not Tavily search). Verify the DataFlag fail-visible pattern aligns with project conventions. Note the NVIDIA NIM deviation from issue #77 checklist — discuss if a TODO comment in the code is needed.

cc @pradyumna-001