### PR TITLE
docs: fix license and project identity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,8 +2,10 @@
 
 ## Project Identity
 
-**FinAgent** — Multi-agent AI financial analyst for Brazilian asset managers (BTG Pactual).
+**FinAgent** — Multi-agent AI financial analyst for Brazilian asset managers.
 Generates daily morning notes + buy/sell/keep recommendations for B3 equities at 6:00 AM BRT.
+
+*Personal project by [@pradyumna-001](https://github.com/pradyumna-001). Target users: asset management professionals.*
 
 ## Tech Stack (Current)
 

--- a/README.md
+++ b/README.md
@@ -182,4 +182,4 @@ See [`docs/issues.md`](docs/issues.md) for full 30-issue, 8-week plan.
 
 ## License
 
-Proprietary — BTG Pactual internal use.
+MIT License — Personal project by [@pradyumna-001](https://github.com/pradyumna-001). Target users: asset management professionals.


### PR DESCRIPTION
Fix license to MIT and clarify this is a personal project for asset management professionals (not formally affiliated with BTG Pactual).