### PR TITLE
feat(issue-97): JWT authentication

### DIFF
--- a/alembic/versions/6f6d0b6496b7_add_password_hash_to_managers.py
+++ b/alembic/versions/6f6d0b6496b7_add_password_hash_to_managers.py
@@ -1,0 +1,28 @@
+"""add password_hash to managers
+
+Revision ID: 6f6d0b6496b7
+Revises: 7a59dd209592
+Create Date: 2026-08-25 17:34:35.139196
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = '6f6d0b6496b7'
+down_revision: Union[str, Sequence[str], None] = '7a59dd209592'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column("managers", sa.Column("password_hash", sa.String(255), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("managers", sa.Column("password_hash"))
+    

--- a/app/api/deps.py
+++ b/app/api/deps.py
@@ -7,6 +7,7 @@ from app.db.session import get_read_session
 from app.services.analysis import AnalysisService
 from app.services.auth import AuthService
 from app.core.security import decode_access_token
+from app.api.errors import InvalidTokenError
 from app.db.models import Manager
 
 
@@ -20,7 +21,11 @@ async def get_current_manager(
     if not credentials:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
 
-    payload = decode_access_token(credentials.credentials)
+    try:
+        payload = decode_access_token(credentials.credentials)
+    except InvalidTokenError:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid or expired token")
+
     if not payload or "manager_id" not in payload:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
 

--- a/app/api/deps.py
+++ b/app/api/deps.py
@@ -1,4 +1,36 @@
+from typing import Annotated
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.session import get_read_session
 from app.services.analysis import AnalysisService
+from app.services.auth import AuthService
+from app.core.security import decode_access_token
+from app.db.models import Manager
+
+
+security = HTTPBearer(auto_error=False)
+
+
+async def get_current_manager(
+        credentials: Annotated[HTTPAuthorizationCredentials, Depends(security)],
+        session: Annotated[AsyncSession, Depends(get_read_session)]
+) -> Manager:
+    if not credentials:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
+
+    payload = decode_access_token(credentials.credentials)
+    if not payload or "manager_id" not in payload:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+
+    auth_service = AuthService(session)
+    manager = await auth_service.get_by_id(payload["manager_id"])
+    if not manager:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Manager not found")
+    
+    return manager
+
 
 def get_analysis_service() -> AnalysisService:
     return AnalysisService(

--- a/app/api/errors.py
+++ b/app/api/errors.py
@@ -14,4 +14,8 @@ class InvalidTriggerPayload(PipelineError):
     """Raised when the trigger request fails semantic validation beyond 
     pydantic's structural checks (e.g., company_id not in manager's book).
     """
-    
+
+class InvalidTokenError(Exception):
+    def __init__(self, message: str = "Invalid or expired token"):
+        self.message = message
+        super().__init__(self.message)

--- a/app/api/routes/auth.py
+++ b/app/api/routes/auth.py
@@ -52,3 +52,4 @@ async def me(current_manager: Annotated[Manager, Depends(get_current_manager)]) 
         "name": current_manager.name,
         "email": current_manager.email
     }
+    

--- a/app/api/routes/auth.py
+++ b/app/api/routes/auth.py
@@ -1,0 +1,54 @@
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, EmailStr
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.session import get_session
+from app.services.auth import AuthService
+from app.core.security import create_access_token
+from app.api.deps import get_current_manager
+from app.db.models import Manager
+
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+class LoginRequest(BaseModel):
+    email: EmailStr
+    password: str
+
+class TokenResponse(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+    manager: dict
+
+
+@router.post("/login")
+async def login(
+    data: LoginRequest,
+    session: Annotated[AsyncSession, Depends(get_session)]
+) -> TokenResponse:
+    auth_service = AuthService(session)
+    manager = await auth_service.authenticate(data.email, data.password)
+    if not manager:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+
+    token = create_access_token({"sub": manager.email, "manager_id": manager.id})
+    return TokenResponse(
+        access_token = token,
+        manager = {
+            "id": manager.id,
+            "name": manager.name,
+            "email": manager.email
+        }
+    )
+
+
+@router.get("/me")
+async def me(current_manager: Annotated[Manager, Depends(get_current_manager)]) -> dict:
+    return {
+        "id": current_manager.id,
+        "name": current_manager.name,
+        "email": current_manager.email
+    }

--- a/app/api/routes/feedback.py
+++ b/app/api/routes/feedback.py
@@ -1,8 +1,11 @@
-from fastapi import APIRouter, Depends, HTTPException, status, Header
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, status, Header, Depends
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.db.models import Feedback
+from app.db.models import Feedback, Manager
+from app.api.deps import get_current_manager
 from app.db.session import get_session
 from app.schemas.feedback import FeedbackCreate, FeedbackResponse
 
@@ -14,15 +17,11 @@ router = APIRouter(prefix="/morning-notes/{note_id}/feedback", tags=["feedback"]
 async def create_feedback(
     note_id: int,
     payload: FeedbackCreate,
-    manager_id: int | None = Header(None, alias="manager-id"),
+    manager: Annotated[Manager, Depends(get_current_manager)],
     session: AsyncSession = Depends(get_session)
 ):
-    if manager_id is None:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="manager_id header required")
-
-    if manager_id <= 0:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="manager_id must be an int greater than 0")
-
+    manager_id = manager.id
+    
     async with session.begin():
         await session.execute(
             text(f"SET LOCAL app.manager_id = '{manager_id}'")

--- a/app/api/routes/feedback.py
+++ b/app/api/routes/feedback.py
@@ -1,6 +1,6 @@
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, status, Header, Depends
+from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -21,7 +21,7 @@ async def create_feedback(
     session: AsyncSession = Depends(get_session)
 ):
     manager_id = manager.id
-    
+
     async with session.begin():
         await session.execute(
             text(f"SET LOCAL app.manager_id = '{manager_id}'")

--- a/app/api/routes/morning_notes.py
+++ b/app/api/routes/morning_notes.py
@@ -2,7 +2,7 @@ import json
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Header, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import StreamingResponse
 
 from sqlalchemy import select, text

--- a/app/api/routes/morning_notes.py
+++ b/app/api/routes/morning_notes.py
@@ -43,7 +43,7 @@ async def list_morning_notes(
 
 @router.get("/{note_id}/stream")
 async def stream_morning_note(
-    note_id: str,
+    note_id: int,
     session: Annotated[AsyncSession, Depends(get_session)],
     manager: Annotated[Manager, Depends(get_current_manager)]
 ):

--- a/app/api/routes/morning_notes.py
+++ b/app/api/routes/morning_notes.py
@@ -58,7 +58,7 @@ async def stream_morning_note(
         if note is None:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Morning note not found")
         
-    run_id = _PIPELINE_REGISTRY.get(note_id)
+    run_id = _PIPELINE_REGISTRY.get(str(note_id))
     if run_id is None:
         raise MorningNoteNotFound(note_id)
 

--- a/app/api/routes/morning_notes.py
+++ b/app/api/routes/morning_notes.py
@@ -9,9 +9,10 @@ from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from app.db.session import get_session
-from app.db.models import MorningNote
 from app.api.errors import MorningNoteNotFound
+from app.api.deps import get_current_manager
+from app.db.session import get_session
+from app.db.models import MorningNote, Manager
 from app.services.pipeline import _PIPELINE_REGISTRY
 from app.services.sse import sse_service
 
@@ -22,10 +23,9 @@ router = APIRouter(prefix="/morning-notes", tags=["morning-notes"])
 @router.get("")
 async def list_morning_notes(
     session: Annotated[AsyncSession, Depends(get_session)],
-    manager_id: int | None = Header(None, alias="manager-id"),
+    manager: Annotated[Manager, Depends(get_current_manager)]
 ) -> list[dict]:
-    if manager_id is None:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="manager_id header required")
+    manager_id = manager.id
 
     async with session.begin():
         await session.execute(
@@ -42,7 +42,22 @@ async def list_morning_notes(
 
 
 @router.get("/{note_id}/stream")
-async def stream_morning_note(note_id: str):
+async def stream_morning_note(
+    note_id: str,
+    session: Annotated[AsyncSession, Depends(get_session)],
+    manager: Annotated[Manager, Depends(get_current_manager)]
+):
+    async with session.begin():
+        stmt = select(MorningNote).where(
+            MorningNote.id == note_id,
+            MorningNote.manager_id == manager.id
+        )
+        result = await session.execute(stmt)
+        note = result.scalar_one_or_none()
+
+        if note is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Morning note not found")
+        
     run_id = _PIPELINE_REGISTRY.get(note_id)
     if run_id is None:
         raise MorningNoteNotFound(note_id)
@@ -66,13 +81,9 @@ async def stream_morning_note(note_id: str):
 async def read_morning_note(
     note_id: int,
     session: Annotated[AsyncSession, Depends(get_session)],
-    manager_id: int | None = Header(None, alias="manager-id"),
+    manager: Annotated[Manager, Depends(get_current_manager)]
 ) -> dict:
-    if manager_id is None:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="manager_id header required")
-
-    if manager_id <= 0:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="manager_id must be an int greater than 0")
+    manager_id = manager.id
 
     async with session.begin():
         await session.execute(

--- a/app/api/routes/pipeline.py
+++ b/app/api/routes/pipeline.py
@@ -1,8 +1,7 @@
 from typing import Annotated
 
-from fastapi import APIRouter, BackgroundTasks, Depends, Header, HTTPException, status
+from fastapi import APIRouter, BackgroundTasks, Depends, status
 from fastapi.responses import JSONResponse
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps import get_current_manager
 from app.db.models import Manager
@@ -19,7 +18,6 @@ async def trigger_pipeline(
     background: BackgroundTasks,
     manager: Annotated[Manager, Depends(get_current_manager)],
 ) -> JSONResponse:
-    manager_id = manager.id
 
     response = TriggerResponse()
     from app.services.pipeline import _PIPELINE_REGISTRY

--- a/app/api/routes/pipeline.py
+++ b/app/api/routes/pipeline.py
@@ -1,6 +1,11 @@
-from fastapi import APIRouter, BackgroundTasks, Header, HTTPException, status
-from fastapi.responses import JSONResponse
+from typing import Annotated
 
+from fastapi import APIRouter, BackgroundTasks, Depends, Header, HTTPException, status
+from fastapi.responses import JSONResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import get_current_manager
+from app.db.models import Manager
 from app.schemas.pipeline import TriggerRequest, TriggerResponse
 from app.services.pipeline import run_pipeline_stub
 
@@ -12,13 +17,9 @@ router = APIRouter(prefix="/pipeline", tags=["pipeline"])
 async def trigger_pipeline(
     payload: TriggerRequest,
     background: BackgroundTasks,
-    manager_id: int | None = Header(None, alias="manager-id"),
+    manager: Annotated[Manager, Depends(get_current_manager)],
 ) -> JSONResponse:
-    if manager_id is None:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="manager-id header required",
-        )
+    manager_id = manager.id
 
     response = TriggerResponse()
     from app.services.pipeline import _PIPELINE_REGISTRY

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -1,0 +1,25 @@
+from datetime import datetime, timedelta, UTC
+from jose import jwt, JWTError
+from app.api.errors import InvalidTokenError
+
+from app.core.config import settings
+
+
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = 30
+
+
+def create_access_token(data: dict, expires_delta: timedelta | None = None) -> str:
+    to_encode = data.copy()
+    expire = datetime.now(UTC) + (expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES))
+    to_encode.update({"exp": expire})
+
+    return jwt.encode(to_encode, settings.SECRET_KEY, algorithm=ALGORITHM)
+
+
+def decode_access_token(token: str) -> dict:
+    try:
+        return jwt.decode(token, settings.SECRET_KEY, algorithms=[ALGORITHM])
+    except JWTError as e:
+        raise InvalidTokenError("Invalid or expired token") from e
+    

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -20,6 +20,7 @@ class Manager(Base):
     morning_notes: Mapped[list["MorningNote"]] = relationship(back_populates="manager")
     name: Mapped[str] = mapped_column(String(120), nullable=False)
     email: Mapped[str] = mapped_column(String(255), unique=True, nullable=False)
+    password_hash: Mapped[str] = mapped_column(String(255), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
 
 

--- a/app/db/session.py
+++ b/app/db/session.py
@@ -13,3 +13,8 @@ SessionLocal = async_sessionmaker(engine, expire_on_commit=False)
 async def get_session() -> AsyncGenerator[AsyncSession, None]:
     async with SessionLocal() as session:
         yield session
+
+
+async def get_read_session() -> AsyncGenerator[AsyncSession, None]:
+    async with SessionLocal() as session:
+        yield session

--- a/app/main.py
+++ b/app/main.py
@@ -8,6 +8,7 @@ from sqlalchemy.exc import SQLAlchemyError
 
 from app.db.session import engine
 from app.middleware.correlation import CorrelationMiddleware
+from app.api.routes.auth import router as auth_router
 from app.api.routes.morning_notes import router as morning_notes_router
 from app.api.routes.feedback import router as feedback_router
 from app.api.routes.pipeline import router as pipeline_router
@@ -26,6 +27,7 @@ app = FastAPI(title="FinAgent", lifespan=lifespan)
 
 
 app.add_middleware(CorrelationMiddleware)
+app.include_router(auth_router)
 app.include_router(morning_notes_router)
 app.include_router(pipeline_router)
 app.include_router(feedback_router)

--- a/app/services/auth.py
+++ b/app/services/auth.py
@@ -17,7 +17,8 @@ class AuthService:
         if (
             manager and manager.password_hash and 
             verify_password(password, manager.password_hash)
-        ): return manager
+        ): 
+            return manager
         return None
 
     async def get_by_id(self, manager_id: int) -> Manager | None:

--- a/app/services/auth.py
+++ b/app/services/auth.py
@@ -17,7 +17,7 @@ class AuthService:
         if (
             manager and manager.password_hash and 
             verify_password(password, manager.password_hash)
-        ): return Manager
+        ): return manager
         return None
 
     async def get_by_id(self, manager_id: int) -> Manager | None:

--- a/app/services/auth.py
+++ b/app/services/auth.py
@@ -1,0 +1,26 @@
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.models import Manager
+from app.utils.security import verify_password
+
+
+class AuthService:
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def authenticate(self, email: str, password: str) -> Manager | None:
+        stmt = select(Manager).where(Manager.email == email)
+        result = await self.session.execute(stmt)
+        manager = result.scalar_one_or_none()
+
+        if (
+            manager and manager.password_hash and 
+            verify_password(password, manager.password_hash)
+        ): return Manager
+        return None
+
+    async def get_by_id(self, manager_id: int) -> Manager | None:
+        stmt = select(Manager).where(Manager.id == manager_id)
+        result = await self.session.execute(stmt)
+        return result.scalar_one_or_none()

--- a/app/utils/security.py
+++ b/app/utils/security.py
@@ -1,0 +1,12 @@
+from passlib.context import CryptContext
+
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def hash_password(password: str) -> str:
+    return pwd_context.hash(password)
+
+
+def verify_password(plain: str, hashed: str) -> bool:
+    return pwd_context.verify(plain, hashed)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "python-jose[cryptography]>=3.3.0",
     "passlib[bcrypt]>=1.7.4",
     "bcrypt==4.0.1",
-
+    "pydantic[email]"
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,10 @@ dependencies = [
     "langgraph-checkpoint-postgres>=3.1.2",
     "celery>=5.4.0",
     "redis>=5.2.0",
+    "python-jose[cryptography]>=3.3.0",
+    "passlib[bcrypt]>=1.7.4",
+    "bcrypt==4.0.1",
+
 ]
 
 [dependency-groups]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,8 @@ from docker.errors import DockerException
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from testcontainers.community.postgres import PostgresContainer
 
+from app.utils.security import hash_password
+
 
 os.environ.setdefault(
     "DATABASE_URL",
@@ -86,10 +88,12 @@ def finagent_app_role(migrated_db_url: str) -> Generator[str, None, None]:
                 "ALTER ROLE finagent_app WITH PASSWORD 'finagent_app_pwd'"
             )
             # Insert test data
+            alice_hash = hash_password("alice123")
+            bob_hash = hash_password("bob123")
             await conn.execute(
-                "INSERT INTO managers (id, name, email) VALUES "
-                "(2, 'Alice', 'alice@example.com'), "
-                "(3, 'Bob', 'bob@example.com') "
+                "INSERT INTO managers (id, name, email, password_hash) VALUES "
+                f"(2, 'Alice', 'alice@example.com', '{alice_hash}'), "
+                f"(3, 'Bob', 'bob@example.com', '{bob_hash}') "
                 "ON CONFLICT (id) DO NOTHING"
             )
             await conn.execute(

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -1,0 +1,133 @@
+from httpx import ASGITransport, AsyncClient
+import pytest
+
+from app.main import app
+from app.core.security import create_access_token
+
+
+def _make_token(manager_id: int, email: str = "test@example.com") -> str:
+    return create_access_token({"manager_id": manager_id, "sub": email})
+
+
+@pytest.mark.asyncio
+async def test_login_valid_credentials_returns_token(
+    bound_engine: None, 
+    finagent_app_role: None
+) -> None:
+    """Valid email + password returns access token."""
+    # 1. Need manager with password hash in DB (add to fixture or setup here)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/auth/login", json={
+            "email": "alice@example.com",
+            "password": "alice123"
+        })
+
+        assert resp.status_code == 200
+        assert "access_token" in resp.json()
+        assert resp.json()["token_type"] == "bearer"
+        assert resp.json()["manager"]["email"] == "alice@example.com"    
+
+
+@pytest.mark.asyncio
+async def test_login_invalid_password_returns_401(
+    bound_engine: None, 
+    finagent_app_role: None
+) -> None:
+    """Wrong password returns 401."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/auth/login", json={
+            "email": "alice@example.com",
+            "password": "wrong-password"
+        })
+
+        assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_login_nonexistent_email_returns_401(
+    bound_engine: None, 
+    finagent_app_role: None
+) -> None:
+    """Non-existent email returns 401 (same as wrong password)."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/auth/login", json={
+            "email": "prady@example.com",
+            "password": "wrong-password"
+        })
+
+        assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_login_missing_fields_returns_422(
+    bound_engine: None, 
+    finagent_app_role: None
+) -> None:
+    """Missing email or password returns 422."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/auth/login", json={
+            "email": "alice@example.com",
+            "password_hash": "alice123"
+        })
+
+        assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_me_valid_token_returns_manager(
+    bound_engine: None, 
+    finagent_app_role: None
+) -> None:
+    """Valid JWT returns manager info."""
+    token = _make_token(2, "alice@example.com")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/auth/me", headers={"Authorization": f"Bearer {token}"})
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["id"] == 2
+        assert data["name"] == "Alice"
+        assert data["email"] == "alice@example.com"
+
+
+@pytest.mark.asyncio
+async def test_me_no_token_returns_401(
+    bound_engine: None, 
+    finagent_app_role: None
+) -> None:
+    """Missing Authorization header returns 401."""
+    token = ""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/auth/me", headers={"Authorization": f"Bearer {token}"})
+        print(resp.json())
+        assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_me_invalid_token_returns_401(
+    bound_engine: None, 
+    finagent_app_role: None
+) -> None:
+    """Invalid/malformed token returns 401."""
+    token = _make_token(2, "alice@example.com")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/auth/me", headers={"Authorization": f"Bearer {token}.not.valid.token"})
+        assert resp.status_code == 401
+
+
+# --- Protected routes with JWT (after routes updated) ---
+
+# @pytest.mark.asyncio
+# async def test_list_morning_notes_jwt_works(
+#     bound_engine: None, 
+#     finagent_app_role: None
+# ) -> None:
+#     """JWT auth works for morning-notes list."""
+#     pass

--- a/tests/integration/test_feedback.py
+++ b/tests/integration/test_feedback.py
@@ -1,19 +1,24 @@
 from httpx import ASGITransport, AsyncClient
 import pytest
 
+from app.core.security import create_access_token
 from app.main import app
+
+
+def _make_token(manager_id: int) -> str:
+    return create_access_token({"sub": str(manager_id), "manager_id": manager_id})
 
 
 async def test_create_feedback_success_201(bound_engine: None, finagent_app_role: None) -> None:
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
-        resp = await client.get("/morning-notes", headers={"manager-id": "2"})
+        resp = await client.get("/morning-notes", headers={"Authorization": f"Bearer {_make_token(2)}"})
         notes = resp.json()
         note_id = notes[0]["id"]
 
         resp = await client.post(
             f"/morning-notes/{note_id}/feedback",
-            headers={"manager-id": "2"},
+            headers={"Authorization": f"Bearer {_make_token(2)}"},
             json={
                 "action": "buy",
                 "justification": "Strong fundamentals",
@@ -29,7 +34,7 @@ async def test_create_feedback_success_201(bound_engine: None, finagent_app_role
 
 
 @pytest.mark.asyncio
-async def test_create_feedback_missing_header_returns_400() -> None:
+async def test_create_feedback_missing_header_returns_401() -> None:
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         resp = await client.post(
@@ -39,21 +44,20 @@ async def test_create_feedback_missing_header_returns_400() -> None:
                 "justification": "Strong fundamentals"
             }
         )
-    assert resp.status_code == 400
-    assert resp.json() == {"detail": "manager_id header required"}
+    assert resp.status_code == 401
 
 
 @pytest.mark.asyncio
-async def test_create_feedback_invalid_manager_id_returns_400(bound_engine: None, finagent_app_role: None) -> None:
+async def test_create_feedback_invalid_manager_id_returns_401(bound_engine: None, finagent_app_role: None) -> None:
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
-        resp = await client.get("/morning-notes", headers={"manager-id": "2"})
+        resp = await client.get("/morning-notes", headers={"Authorization": f"Bearer {_make_token(2)}"})
         notes = resp.json()
         note_id = notes[0]["id"]
 
         resp = await client.post(
             f"/morning-notes/{note_id}/feedback",
-            headers={"manager-id": "-1"},
+            headers={"Authorization": f"Bearer {_make_token(-1)}"},
             json={
                 "action": "buy",
                 "justification": "Strong fundamentals",
@@ -61,8 +65,7 @@ async def test_create_feedback_invalid_manager_id_returns_400(bound_engine: None
             }
         )
 
-        assert resp.status_code == 400
-        assert resp.json() == {"detail": "manager_id must be an int greater than 0"}
+        assert resp.status_code == 401
 
 
 @pytest.mark.asyncio
@@ -73,7 +76,7 @@ async def test_create_feedback_valid_manager_non_existent_note_id_returns_404(bo
 
         resp = await client.post(
             f"/morning-notes/{note_id}/feedback",
-            headers={"manager-id": "2"},
+            headers={"Authorization": f"Bearer {_make_token(2)}"},
             json={
                 "action": "buy",
                 "justification": "Strong fundamentals",
@@ -89,13 +92,13 @@ async def test_create_feedback_valid_manager_non_existent_note_id_returns_404(bo
 async def test_manager_a_posts_on_manager_b_note_returns_404(bound_engine: None, finagent_app_role: None) -> None:
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
-        resp = await client.get("/morning-notes", headers={"manager-id": "2"})
+        resp = await client.get("/morning-notes", headers={"Authorization": f"Bearer {_make_token(2)}"})
         notes = resp.json()
         note_id = notes[0]["id"]
 
         resp = await client.post(
             f"/morning-notes/{note_id}/feedback",
-            headers={"manager-id": "1"},
+            headers={"Authorization": f"Bearer {_make_token(3)}"},
             json={
                 "action": "buy",
                 "justification": "Strong fundamentals",
@@ -111,13 +114,13 @@ async def test_manager_a_posts_on_manager_b_note_returns_404(bound_engine: None,
 async def test_create_feedback_missing_fields_returns_422(bound_engine: None, finagent_app_role: None) -> None:
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
-        resp = await client.get("/morning-notes", headers={"manager-id": "2"})
+        resp = await client.get("/morning-notes", headers={"Authorization": f"Bearer {_make_token(2)}"})
         notes = resp.json()
         note_id = notes[0]["id"]
 
         resp = await client.post(
             f"/morning-notes/{note_id}/feedback",
-            headers={"manager-id": "2"},
+            headers={"Authorization": f"Bearer {_make_token(2)}"},
             json={
                 "justification": "Strong fundamentals",
             }
@@ -130,13 +133,13 @@ async def test_create_feedback_missing_fields_returns_422(bound_engine: None, fi
 async def test_create_feedback_invalid_action_returns_422(bound_engine: None, finagent_app_role: None) -> None:
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
-        resp = await client.get("/morning-notes", headers={"manager-id": "2"})
+        resp = await client.get("/morning-notes", headers={"Authorization": f"Bearer {_make_token(2)}"})
         notes = resp.json()
         note_id = notes[0]["id"]
 
         resp = await client.post(
             f"/morning-notes/{note_id}/feedback",
-            headers={"manager-id": "2"},
+            headers={"Authorization": f"Bearer {_make_token(2)}"},
             json={
                 "action": "stand still",
                 "justification": "Strong fundamentals",
@@ -151,13 +154,13 @@ async def test_create_feedback_invalid_action_returns_422(bound_engine: None, fi
 async def test_create_feedback_short_justification_422(bound_engine: None, finagent_app_role: None) -> None:
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
-        resp = await client.get("/morning-notes", headers={"manager-id": "2"})
+        resp = await client.get("/morning-notes", headers={"Authorization": f"Bearer {_make_token(2)}"})
         notes = resp.json()
         note_id = notes[0]["id"]
 
         resp = await client.post(
             f"/morning-notes/{note_id}/feedback",
-            headers={"manager-id": "2"},
+            headers={"Authorization": f"Bearer {_make_token(2)}"},
             json={
                 "action": "buy",
                 "justification": "short",
@@ -171,13 +174,13 @@ async def test_create_feedback_short_justification_422(bound_engine: None, finag
 async def test_create_duplicated_feedback_returns_409(bound_engine: None, finagent_app_role: None) -> None:
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
-        resp = await client.get("/morning-notes", headers={"manager-id": "2"})
+        resp = await client.get("/morning-notes", headers={"Authorization": f"Bearer {_make_token(2)}"})
         notes = resp.json()
         note_id = [n["id"] for n in notes if n["note_text"] == "note-a1"][0]
 
         resp = await client.post(
             f"/morning-notes/{note_id}/feedback",
-            headers={"manager-id": "2"},
+            headers={"Authorization": f"Bearer {_make_token(2)}"},
             json={
                 "action": "buy",
                 "justification": "Strong fundamentals",

--- a/tests/integration/test_morning_notes.py
+++ b/tests/integration/test_morning_notes.py
@@ -2,24 +2,27 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 
 from app.main import app
+from app.core.security import create_access_token
+
+
+def _make_token(manager_id: int) -> str:
+    return create_access_token({"sub": str(manager_id), "manager_id": manager_id})
 
 
 @pytest.mark.asyncio
-async def test_list_morning_notes_missing_header_returns_400() -> None:
+async def test_list_morning_notes_missing_header_returns_401() -> None:
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         resp = await client.get("/morning-notes")
-    assert resp.status_code == 400
-    assert resp.json() == {"detail": "manager_id header required"}
+    assert resp.status_code == 401
 
 
 @pytest.mark.asyncio
-async def test_list_morning_notes_with_header_returns_list(
-    bound_engine: None,
-) -> None:
+async def test_list_morning_notes_with_header_returns_list(bound_engine: None, finagent_app_role: None) -> None:
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
-        resp = await client.get("/morning-notes", headers={"manager-id": "2"})
+        resp = await client.get("/morning-notes", headers={"Authorization": f"Bearer {_make_token(2)}"})
+    print(resp.json())
     assert resp.status_code == 200
     assert isinstance(resp.json(), list)
 
@@ -28,13 +31,13 @@ async def test_list_morning_notes_with_header_returns_list(
 async def test_read_morning_notes_with_header_returns_all_fields(bound_engine: None, finagent_app_role: None) -> None:
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
-        resp = await client.get("/morning-notes", headers={"manager-id": "2"})
+        resp = await client.get("/morning-notes", headers={"Authorization": f"Bearer {_make_token(2)}"})
         notes = resp.json()
         note_id = notes[0]["id"]
 
         resp = await client.get(
             f"/morning-notes/{note_id}",
-            headers={"manager-id": "2"}
+            headers={"Authorization": f"Bearer {_make_token(2)}"}
         )
 
         assert resp.status_code == 200
@@ -65,30 +68,29 @@ async def test_read_morning_notes_with_header_returns_all_fields(bound_engine: N
 
 
 @pytest.mark.asyncio
-async def test_read_morning_note_missing_header_returns_400(bound_engine: None, finagent_app_role: None) -> None:
+async def test_read_morning_note_missing_header_returns_401(bound_engine: None, finagent_app_role: None) -> None:
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
-        resp = await client.get("/morning-notes", headers={"manager-id": "2"})
+        resp = await client.get("/morning-notes", headers={"Authorization": f"Bearer {_make_token(2)}"})
         notes = resp.json()
         note_id = notes[0]["id"]
 
         resp = await client.get(f"/morning-notes/{note_id}")
 
-    assert resp.status_code == 400
-    assert resp.json() == {"detail": "manager_id header required"}
+    assert resp.status_code == 401
 
 
 @pytest.mark.asyncio
 async def test_read_morning_notes_rls_isolation_returns_404(bound_engine: None, finagent_app_role: None) -> None:
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
-        resp = await client.get("/morning-notes", headers={"manager-id": "2"})
+        resp = await client.get("/morning-notes", headers={"Authorization": f"Bearer {_make_token(2)}"})
         notes = resp.json()
         note_id = notes[0]["id"]
 
         resp = await client.get(
             f"/morning-notes/{note_id}",
-            headers={"manager-id": "1"}
+            headers={"Authorization": f"Bearer {_make_token(3)}"}
         )
 
         assert resp.status_code == 404
@@ -103,7 +105,7 @@ async def test_read_morning_notes_nonexistent_note_returns_404(bound_engine: Non
 
         resp = await client.get(
             f"/morning-notes/{note_id}",
-            headers={"manager-id": "2"}
+            headers={"Authorization": f"Bearer {_make_token(2)}"}
         )
 
         assert resp.status_code == 404

--- a/tests/integration/test_pipeline.py
+++ b/tests/integration/test_pipeline.py
@@ -1,18 +1,23 @@
 import pytest
 from httpx import ASGITransport, AsyncClient
 
+from app.core.security import create_access_token
 from app.main import app
 
 
+def _make_token(manager_id: int) -> str:
+    return create_access_token({"sub": str(manager_id), "manager_id": manager_id})
+
+
 @pytest.mark.asyncio
-async def test_trigger_returns_202_with_ids() -> None:
+async def test_trigger_returns_202_with_ids(bound_engine: None, finagent_app_role: None) -> None:
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         resp = await client.post(
             "/pipeline/trigger",
-            headers={"manager-id": "1"},
+            headers={"Authorization": f"Bearer {_make_token(2)}"},
             json={
-                "manager_id": 1,
+                "manager_id": 2,
                 "portfolio_id": 42,
                 "company_id": 7,
             },
@@ -25,7 +30,7 @@ async def test_trigger_returns_202_with_ids() -> None:
 
 
 @pytest.mark.asyncio
-async def test_trigger_missing_header_header_returns_400() -> None:
+async def test_trigger_missing_header_header_returns_401(bound_engine: None, finagent_app_role: None) -> None:
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         resp = await client.post(
@@ -36,38 +41,16 @@ async def test_trigger_missing_header_header_returns_400() -> None:
                 "company_id": 7,
             },
         )
-    assert resp.status_code == 400
-
-
-@pytest.mark.skip(reason="Old stub test - replaced by test_sse.py integration tests")
-@pytest.mark.asyncio
-async def test_stream_known_note_returns_one_event() -> None:
-    transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://") as client:
-        trigger = await client.post(
-            "/pipeline/trigger",
-            headers={"manager-id": "1"},
-            json={"manager_id": 1, "portfolio_id": 42, "company_id": 7},
-        )
-        note_id = trigger.json()["morning_note_id"]
-
-        async with client.stream(
-            "GET", f"/morning-notes/{note_id}/stream"
-        ) as stream_resp:
-            assert stream_resp.status_code == 200
-            lines = []
-            async for line in stream_resp.aiter_lines():
-                lines.append(line)
-
-        data_lines = [line for line in lines if line.startswith("data:")]
-        assert len(data_lines) == 1
-        assert note_id in data_lines[0]
+    assert resp.status_code == 401
 
 
 @pytest.mark.asyncio
-async def test_stream_unknown_note_returns_404() -> None:
+async def test_stream_unknown_note_returns_404(bound_engine: None, finagent_app_role: None) -> None:
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
-        resp = await client.get("/morning-notes/00000000-0000-0000-0000-000000000000/stream")
-
+        resp = await client.get(
+            "/morning-notes/99999/stream",
+            headers={"Authorization": f"Bearer {_make_token(2)}"},
+        )
+    
     assert resp.status_code == 404

--- a/tests/unit/test_auth_deps.py
+++ b/tests/unit/test_auth_deps.py
@@ -1,0 +1,91 @@
+from datetime import datetime, timedelta, UTC
+
+import pytest
+from jose import jwt
+
+from app.api.errors import InvalidTokenError
+
+from app.core.security import (
+    create_access_token,
+    decode_access_token,
+    ALGORITHM,
+    ACCESS_TOKEN_EXPIRE_MINUTES,
+)
+from app.core.config import settings
+
+
+def test_create_access_token_returns_string() -> None:
+    """create_access_token returns a non-empty string (JWT)."""
+    result = create_access_token({"sub": "1"})
+
+    assert len(result) > 0
+    assert isinstance(result, str)
+
+
+def test_create_access_token_includes_exp_claim() -> None:
+    """Token payload contains 'exp' claim (expiration timestamp)."""
+    token = create_access_token({"sub": "1", "email": "test@example.com"})
+    payload = jwt.decode(token, key="", options={"verify_signature": False})
+
+    assert "exp" in payload
+    assert isinstance(payload["exp"], int)
+    
+
+def test_create_access_token_custom_expires_delta() -> None:
+    """Custom expires_delta overrides default ACCESS_TOKEN_EXPIRE_MINUTES."""
+    token = create_access_token({"sub": "1"}, expires_delta=timedelta(minutes=5))
+    payload = jwt.decode(token, key="", options={"verify_signature": False})
+
+    now = datetime.now(UTC)
+    expected_exp = now + timedelta(minutes=5)
+    assert abs(payload["exp"] - expected_exp.timestamp()) < 10
+     
+
+def test_decode_access_token_valid_returns_payload() -> None:
+    """Valid token decoded successfully, returns payload dict."""
+    token = create_access_token({"sub": "1", "email": "test@example.com"}, expires_delta=timedelta(minutes=5))
+    res = decode_access_token(token)
+
+    assert isinstance(res, dict)
+    assert res["sub"] == "1"
+    assert res["email"] == "test@example.com"
+    assert "sub" in res
+    assert "exp" in res
+
+
+def test_decode_access_token_expired_raises() -> None:
+    """Expired token raises JWTError (or custom InvalidTokenError)."""
+    token = create_access_token({"sub": "1", "email": "test@example.com"}, expires_delta=timedelta(minutes=-10))
+    with pytest.raises(InvalidTokenError):
+        decode_access_token(token)
+
+
+def test_decode_access_token_invalid_signature_raises() -> None:
+    """Token signed with different secret raises JWTError."""
+    to_encode = {"sub": "1", "email": "test@example.com"}
+    token = jwt.encode(to_encode, "wrong-secret", algorithm=ALGORITHM)
+
+    with pytest.raises(InvalidTokenError):
+        decode_access_token(token)
+    
+
+def test_decode_access_token_malformed_raises() -> None:
+    """Malformed token string (not a valid JWT) raises JWTError."""
+    with pytest.raises(InvalidTokenError):
+        decode_access_token("not.a.valid.token")    
+
+
+def test_algorithm_constant_is_hs256() -> None:
+    """ALGORITHM constant matches expected HS256."""
+    assert ALGORITHM == "HS256"
+
+
+def test_access_token_expire_minutes_default_30() -> None:
+    """ACCESS_TOKEN_EXPIRE_MINUTES default is 30."""
+    assert ACCESS_TOKEN_EXPIRE_MINUTES == 30
+
+
+def test_secret_key_from_settings() -> None:
+    """SECRET_KEY is loaded from settings (non-empty in test env)."""
+    assert settings.SECRET_KEY
+    assert len(settings.SECRET_KEY) > 0

--- a/uv.lock
+++ b/uv.lock
@@ -170,6 +170,25 @@ wheels = [
 ]
 
 [[package]]
+name = "bcrypt"
+version = "4.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/ae/3af7d006aacf513975fd1948a6b4d6f8b4a307f8a244e1a3d3774b297aad/bcrypt-4.0.1.tar.gz", hash = "sha256:27d375903ac8261cfe4047f6709d16f7d18d39b1ec92aaf72af989552a650ebd", size = 25498, upload-time = "2022-10-09T15:36:49.775Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/d4/3b2657bd58ef02b23a07729b0df26f21af97169dbd0b5797afa9e97ebb49/bcrypt-4.0.1-cp36-abi3-macosx_10_10_universal2.whl", hash = "sha256:b1023030aec778185a6c16cf70f359cbb6e0c289fd564a7cfa29e727a1c38f8f", size = 473446, upload-time = "2022-10-09T15:36:25.481Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/0a/1582790232fef6c2aa201f345577306b8bfe465c2c665dec04c86a016879/bcrypt-4.0.1-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:08d2947c490093a11416df18043c27abe3921558d2c03e2076ccb28a116cb6d0", size = 583044, upload-time = "2022-10-09T15:37:09.447Z" },
+    { url = "https://files.pythonhosted.org/packages/41/16/49ff5146fb815742ad58cafb5034907aa7f166b1344d0ddd7fd1c818bd17/bcrypt-4.0.1-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0eaa47d4661c326bfc9d08d16debbc4edf78778e6aaba29c1bc7ce67214d4410", size = 583189, upload-time = "2022-10-09T15:37:10.69Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/48/fd2b197a9741fa790ba0b88a9b10b5e88e62ff5cf3e1bc96d8354d7ce613/bcrypt-4.0.1-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ae88eca3024bb34bb3430f964beab71226e761f51b912de5133470b649d82344", size = 593473, upload-time = "2022-10-09T15:36:27.195Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/50/e683d8418974a602ba40899c8a5c38b3decaf5a4d36c32fc65dce454d8a8/bcrypt-4.0.1-cp36-abi3-manylinux_2_24_x86_64.whl", hash = "sha256:a522427293d77e1c29e303fc282e2d71864579527a04ddcfda6d4f8396c6c36a", size = 593249, upload-time = "2022-10-09T15:36:28.481Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/a7/ee4561fd9b78ca23c8e5591c150cc58626a5dfb169345ab18e1c2c664ee0/bcrypt-4.0.1-cp36-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:fbdaec13c5105f0c4e5c52614d04f0bca5f5af007910daa8b6b12095edaa67b3", size = 583586, upload-time = "2022-10-09T15:37:11.962Z" },
+    { url = "https://files.pythonhosted.org/packages/64/fe/da28a5916128d541da0993328dc5cf4b43dfbf6655f2c7a2abe26ca2dc88/bcrypt-4.0.1-cp36-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:ca3204d00d3cb2dfed07f2d74a25f12fc12f73e606fcaa6975d1f7ae69cacbb2", size = 593659, upload-time = "2022-10-09T15:36:30.049Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/4f/3632a69ce344c1551f7c9803196b191a8181c6a1ad2362c225581ef0d383/bcrypt-4.0.1-cp36-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:089098effa1bc35dc055366740a067a2fc76987e8ec75349eb9484061c54f535", size = 613116, upload-time = "2022-10-09T15:37:14.107Z" },
+    { url = "https://files.pythonhosted.org/packages/87/69/edacb37481d360d06fc947dab5734aaf511acb7d1a1f9e2849454376c0f8/bcrypt-4.0.1-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:e9a51bbfe7e9802b5f3508687758b564069ba937748ad7b9e890086290d2f79e", size = 624290, upload-time = "2022-10-09T15:36:31.251Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ca/6a534669890725cbb8c1fb4622019be31813c8edaa7b6d5b62fc9360a17e/bcrypt-4.0.1-cp36-abi3-win32.whl", hash = "sha256:2caffdae059e06ac23fce178d31b4a702f2a3264c20bfb5ff541b338194d8fab", size = 159428, upload-time = "2022-10-09T15:36:32.893Z" },
+    { url = "https://files.pythonhosted.org/packages/46/81/d8c22cd7e5e1c6a7d48e41a1d1d46c92f17dae70a54d9814f746e6027dec/bcrypt-4.0.1-cp36-abi3-win_amd64.whl", hash = "sha256:8a68f4341daf7522fe8d73874de8906f3a339048ba406be6ddc1b3ccb16fc0d9", size = 152930, upload-time = "2022-10-09T15:36:34.635Z" },
+]
+
+[[package]]
 name = "beautifulsoup4"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -451,6 +470,62 @@ wheels = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "50.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/ad/5d6702db60b1e40b41ef513b6967ff5848f307d50f8449baf1634f5908f1/cryptography-50.0.1.tar.gz", hash = "sha256:5dd9bda1c12b4162f6ff568eeb5e0ff956c28d14406e875cfe8a63a2d414ff20", size = 880381, upload-time = "2026-08-25T19:45:45.499Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/19/797e2aaac9df6a66f1550f49979dc1b1e39ecd2077501c30efa81e8d5d67/cryptography-50.0.1-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:b8f852c65863251b9e3a1b8c150ce21e59b522dbb6a7d4bc80e680d38388e986", size = 4010153, upload-time = "2026-08-25T19:44:03.155Z" },
+    { url = "https://files.pythonhosted.org/packages/90/34/9ce9a62ed9dc82ca9fd6a34445b6904af56e5f38b3eae2ed32e49c36053d/cryptography-50.0.1-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:53e279950892dc102c6b4e52af03ae5ea92fac572a1ddab78ca73a997f62b69f", size = 4723133, upload-time = "2026-08-25T19:44:05.461Z" },
+    { url = "https://files.pythonhosted.org/packages/57/26/e6d4fc8512a51a5f9ee7bfdbfb853bce1197087df40c9ad993ad370b846f/cryptography-50.0.1-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ff838d62ec1bfce4f9ba7fa16f4a7b554cd8d0c299e6be37502161a660c84eef", size = 4712478, upload-time = "2026-08-25T19:44:07.375Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/de/d3cdc2815697aae84126cbd6a030ca7b6b452e28a88b501b836bd3aa7a86/cryptography-50.0.1-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e74591e283fe6eb956416c929eb58262a719fe0311fd9054c62c3350ed8760d8", size = 4730726, upload-time = "2026-08-25T19:44:09.294Z" },
+    { url = "https://files.pythonhosted.org/packages/55/32/38c0d344b98c06d34b5df8946565a9c0d6dbf32c8e0730a7f05f0a3c6cab/cryptography-50.0.1-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:5fe002589592ed749ce77fe0695fcbd3500dd61d7d6db5858a7544c612fa8e45", size = 5353524, upload-time = "2026-08-25T19:44:11.96Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/1b/82f0f0d8858d4432be1af790477edf62aef90324041aa07c57e57bef1af7/cryptography-50.0.1-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:51593d180cf6d179bde5c5d065bed81386b1f381656ae7d042b7ffc87a9895ad", size = 4746720, upload-time = "2026-08-25T19:44:14.051Z" },
+    { url = "https://files.pythonhosted.org/packages/29/ba/042ca458b8c64348c768284b5d23e69b92ed53d057ab779fee628564676d/cryptography-50.0.1-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:359e62deae718bce96170e223fdcb6357e4fbd3bb7a3a75f4430763532560e49", size = 4361866, upload-time = "2026-08-25T19:44:16.167Z" },
+    { url = "https://files.pythonhosted.org/packages/39/3b/e96c1ef71edef71057c7e3c3d982ce8fda554e0c52d0cc19c18845cde3eb/cryptography-50.0.1-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:e2ca8fd1b6b4b82a1c4cb02841d0837e3c12336c2e24b520ab8ab3b969733d8f", size = 4730028, upload-time = "2026-08-25T19:44:18.085Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/38/45abd72ef63f2e7d0754a6cacf97bd8b69512ace7f6130d24c39ece65da2/cryptography-50.0.1-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:76de83fbd91ac49c0feaaa983d0748fd7a53176afac5fb3bf7478d244f0eb527", size = 5308405, upload-time = "2026-08-25T19:44:20.197Z" },
+    { url = "https://files.pythonhosted.org/packages/85/66/6ccca4722987ddedaa7fc9c3f4708af7431f5535666c174350830888c6b7/cryptography-50.0.1-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:51afcfceb15597cf2635068e4ac9a56b2abde622edde17f37d85fd7b5306497a", size = 4746230, upload-time = "2026-08-25T19:44:22.376Z" },
+    { url = "https://files.pythonhosted.org/packages/13/0e/b1f92e013228111413f2e6743948b80bc24dfd3c1b87ba98ceea16f5df89/cryptography-50.0.1-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:be224a65493ec5b74a158ff22a5522ce4a5ca1e543c647a3a4730d4a09e5f959", size = 4862596, upload-time = "2026-08-25T19:44:24.472Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/22/c3654cccc856e9d682817b04ac3ee79731cb09ca6f95996a95c904de2883/cryptography-50.0.1-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9ebcdd5519be9b652a46f507817a74591774fc3d6923ac364e4dfa64e36b291b", size = 5014082, upload-time = "2026-08-25T19:44:26.709Z" },
+    { url = "https://files.pythonhosted.org/packages/42/8b/cb12b1b60c91b074ca6bf0fdd59aa8f10d8bc5f73af8faece86ef0421b37/cryptography-50.0.1-cp311-abi3-win_amd64.whl", hash = "sha256:aed8db4f6d71c51efb89530e12d9464e7bf2923d46c3205dc794a2a93f8c0648", size = 3842826, upload-time = "2026-08-25T19:44:28.784Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/f0/424cb557d99aa86ac55da5e2add02e2882e44047b6264f93ade1b975a993/cryptography-50.0.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:30a125032e5642a21ff816e021152bd4e7e94f03eff3f4b7fca41cd22bc3110f", size = 3973525, upload-time = "2026-08-25T19:44:30.7Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/72/3a2711d967977ab5fc80b782837c7e8d1ac7445e764c20c381a265c57ef3/cryptography-50.0.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a0b1a59e3a089064a0ec309e9428c8e3ae4e161419d20ac33600767e83fc658a", size = 4708817, upload-time = "2026-08-25T19:44:32.773Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/f2/bb1f56e10815b789df0b409a69fa4992ff3d3fef9c72747f4a6b26fed38e/cryptography-50.0.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8921d58f426793c5f1b47f0b59575780de9a095214958d0eb37d909593db8367", size = 4697300, upload-time = "2026-08-25T19:44:35.144Z" },
+    { url = "https://files.pythonhosted.org/packages/08/bd/ed5396be499ffcf8807a585bfe38b71a1fbdd1c342b4f9b6d0ef5162a946/cryptography-50.0.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:a8f40ea47330e71b594a7e246898f93177c259490c63183dbaf9e571d71ed9a5", size = 4716039, upload-time = "2026-08-25T19:44:37.192Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/6e/1cf405c5c8e8df7545378048e954792f00b7f2367af8863ce8b8f3e10607/cryptography-50.0.1-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:a255449073358275b64b67d3f595f268bbef70e72b6edb65e0c70c735bf739c9", size = 5332388, upload-time = "2026-08-25T19:44:39.16Z" },
+    { url = "https://files.pythonhosted.org/packages/47/92/b4317e8c32c4f47b062f5398bd79106b220a124546f42be83bf32b761e2a/cryptography-50.0.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:8df2de9102026855887e4587084f6eabd80ed0f345b8ad8a7ac27ab9bf4723e0", size = 4730293, upload-time = "2026-08-25T19:44:41.298Z" },
+    { url = "https://files.pythonhosted.org/packages/39/0d/a1e7633e2c744d0f2983320a27e924ef2264c79c56e1a58d5fb0a1cfd413/cryptography-50.0.1-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:ac02b07824d4d1001bd4367599f839c19cb171924c796e52c23508ac14c2c0cc", size = 4346031, upload-time = "2026-08-25T19:44:43.245Z" },
+    { url = "https://files.pythonhosted.org/packages/88/dd/b215616f9bab3fc18510c78a4e5c9f362d77838503c363dc747c7d4f5c6f/cryptography-50.0.1-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:cbf74a81765ee67413503ca6e26dcc4f6f5a519822436cc0a1b97aab6c1b8a17", size = 4715344, upload-time = "2026-08-25T19:44:45.291Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/1b/ec3ebd31741d0e963612c4fe43caa39341b9b1e031e469820e42e4c83918/cryptography-50.0.1-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:16c5ecd954b3330ebfb6605eca4fd952da8bef376551d5cc264534e3770a9ee6", size = 5287201, upload-time = "2026-08-25T19:44:47.297Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/01/0127d11a762b31a9ee0221894f540318761783f3fdc4bc5d057698caebd5/cryptography-50.0.1-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:79bf008d1f9af6071c797ad133e39915dfee7614f18f18f4db9072eb715064a3", size = 4730023, upload-time = "2026-08-25T19:44:49.435Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/b9/e7425ebfb599241a0c1d7000f1b466c3062da66c19d9525031315dff7213/cryptography-50.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:330fbb252391c596f1ae42c5754449dc924e6ad012dca8efe0d703f9f2d12ec6", size = 4847362, upload-time = "2026-08-25T19:44:51.94Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/fd/60d0ddf4defa12e482c9d5e0f554384d6e8ab25341fd15f060028fd92e6a/cryptography-50.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:42be3bb70596b3abe4ac097b75be223e8b3ab614a0e5de068e3dcc54d71d6149", size = 4999247, upload-time = "2026-08-25T19:44:53.876Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/56/bc4f2b209e766c93372cfcd59b781a0b2b59700f62a969580415b699c2b2/cryptography-50.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:f74455bb086a85d5e81246412602aaa97ed095e504cd40dd261ef50be42205bf", size = 3825806, upload-time = "2026-08-25T19:44:56.209Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a9/ee16a903f13755e914d1eecc482fe64d1f10761c3960e5d8fa6837377aff/cryptography-50.0.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ca83d00d9e69cd5eb63f2e69c3a5a59e0cecae5ae14c6ae0b35830fe3b37bad0", size = 4035307, upload-time = "2026-08-25T19:44:58.305Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/a5/9ec7e81e8526c0d7a387d73386b2daed3f39e10d81a85930bd1b6bfba65c/cryptography-50.0.1-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:05ba322c4da95b262a212c345af888ef2c37c88c0509756ea00a0e6d68850f23", size = 4751900, upload-time = "2026-08-25T19:45:00.401Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/3c/0e77bd5ffcf078e9dd27d3074aad6c030d9b10d0bf69329d573c927a188c/cryptography-50.0.1-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e22dfed744bd4002e909464cb23d2f0b05c6f3113a79ef2e9864a53db737c733", size = 4738357, upload-time = "2026-08-25T19:45:02.786Z" },
+    { url = "https://files.pythonhosted.org/packages/27/3a/3c5f80daa4dcd47323c7af8a2fcb90de27a33564d4fcac69846c0972691a/cryptography-50.0.1-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:4c4188f7c0cf655be5c06342b817ed0f9595b69ffa2b12026e5353eed29dea88", size = 4758474, upload-time = "2026-08-25T19:45:04.889Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/2b/214cf0cf93db9628c3c20c896b229f327f6fb1b20e4b3743d8ad3f00af8b/cryptography-50.0.1-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2ebbfb0f1fed745e91796e3e1080a1440423fdae8ece1b995a1d80883a409054", size = 5375862, upload-time = "2026-08-25T19:45:07.163Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/51/3f9701867a46b6c1740c9b52fc4d3bed6cbdcfedcc9b6e64305c07f39cff/cryptography-50.0.1-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:407fe2b6db00939c05c0e945e9914238f2f0a430974839429dafc82b1ee6bee5", size = 4772942, upload-time = "2026-08-25T19:45:09.396Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/5c/13ea642e08e2544d0f5396122055f4820cfacb3203562197b5967125ea97/cryptography-50.0.1-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:2b34d76a652ea2b6faf777c35df230c5637842cd904e04f16230c3f9f03e4361", size = 4383347, upload-time = "2026-08-25T19:45:11.659Z" },
+    { url = "https://files.pythonhosted.org/packages/84/d5/7d1fe1cb93f91c428093ff234e128c89ba8ea61a6f26aab406081f9b996e/cryptography-50.0.1-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:01f41478cf33fc605a6a089cd56d28b45c6c0b45a1928b61797f2621a04bac71", size = 4758050, upload-time = "2026-08-25T19:45:13.745Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/04/557fc5ead96a829e0bc812a3b9dc4a52a2f27e4f7f5950da7ff27653a805/cryptography-50.0.1-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:fc3ed7ebd2a8c96f5b166de0ab9b624996bef3b07bbeb19364dfb78222c22c80", size = 5332955, upload-time = "2026-08-25T19:45:16.193Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/eb/5d7124083e8d8cda8f5b348f544b71ad6f707ad63193758ef4d8e569da02/cryptography-50.0.1-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9dde0a357190eb3b1da1bb9ab750e9c85cba82ca5977aa0836cbb94e92611239", size = 4772694, upload-time = "2026-08-25T19:45:18.315Z" },
+    { url = "https://files.pythonhosted.org/packages/63/8e/f1f955e0921dd2b6d22eae7e8d24a4c4b638d10735ffbf6a71f99eb0fcb8/cryptography-50.0.1-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd3718b960d0b5dd213cdf03f3bcb7000e69dda0de8b956061947ff6bcff5558", size = 4888413, upload-time = "2026-08-25T19:45:20.4Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/ab/89e2b798d2c3925f82e2bb72d5979f3d2f6da2dd22ef4a8cd8b70d920039/cryptography-50.0.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:2a93d05e34d5f67fba6f891fe85d929999baa7195e853923ea6d7576c9e68c5e", size = 5044355, upload-time = "2026-08-25T19:45:22.353Z" },
+    { url = "https://files.pythonhosted.org/packages/99/89/87ef49ffe383ef4e147d27b7bf2088fb0b54ea409dd87b5a89442e5828a5/cryptography-50.0.1-cp39-abi3-win_amd64.whl", hash = "sha256:55d16b1ef3ee0958d893a977b19777887e546c9954ea81b200c3301a864013f2", size = 3875429, upload-time = "2026-08-25T19:45:24.418Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/27/8d207af749c453ee17ea087340b3f2b4adef75aadd1d277b1b129bdda84e/cryptography-50.0.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:9cb3cb952cf5a8abd50c782a98a89d71699715e802fe349704b47f2425b42a94", size = 3974350, upload-time = "2026-08-25T19:45:26.551Z" },
+    { url = "https://files.pythonhosted.org/packages/14/9a/6d3a4d7852e22d657438b7bf51f66102c7d71c0e1fafeec652281d0403e5/cryptography-50.0.1-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:5fe939deeb161024a6be98229c953b6591fef1f41214497a78fe793a244c017f", size = 4698675, upload-time = "2026-08-25T19:45:28.658Z" },
+    { url = "https://files.pythonhosted.org/packages/73/35/5c3717edf9e68a0550ce04e28eab493fe545eccd81742af03f6a75fe260b/cryptography-50.0.1-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:fb4b9672d389c738b175c4166e78310f8a70358886aacd9173ee03a85ffdc671", size = 4707410, upload-time = "2026-08-25T19:45:30.816Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/e0/e786934472e3ac4ecdecc7b129a0ca1a2a40dffdafcf2c3ea9d4397f8def/cryptography-50.0.1-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:d63ae8f6481fec907ac0f588eee8a90aefde112c633131fe540e5711ddbb5a4e", size = 4698378, upload-time = "2026-08-25T19:45:33.043Z" },
+    { url = "https://files.pythonhosted.org/packages/51/cf/5b3f53a0b74d122f023476ede40ba5d3e70d5cf475f73b899740d26a4fb2/cryptography-50.0.1-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:804728ce710890870f3aaa344b2e161172d258d768ac139d02cfd9092d0d94e6", size = 4706889, upload-time = "2026-08-25T19:45:35.086Z" },
+    { url = "https://files.pythonhosted.org/packages/71/44/711e61f7d014be825ef79b285b047292d1bf893732ac1bc030a351fb517f/cryptography-50.0.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:693c99b49bd37d0d096e4334c10232c77248c415b98d35236094cdf96d57258b", size = 3824006, upload-time = "2026-08-25T19:45:37.281Z" },
+]
+
+[[package]]
 name = "curl-cffi"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -506,6 +581,18 @@ wheels = [
 ]
 
 [[package]]
+name = "ecdsa"
+version = "0.19.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/ca/8de7744cb3bc966c85430ca2d0fcaeea872507c6a4cf6e007f7fe269ed9d/ecdsa-0.19.2.tar.gz", hash = "sha256:62635b0ac1ca2e027f82122b5b81cb706edc38cd91c63dda28e4f3455a2bf930", size = 202432, upload-time = "2026-03-26T09:58:17.675Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/79/119091c98e2bf49e24ed9f3ae69f816d715d2904aefa6a2baa039a2ba0b0/ecdsa-0.19.2-py2.py3-none-any.whl", hash = "sha256:840f5dc5e375c68f36c1a7a5b9caad28f95daa65185c9253c0c08dd952bb7399", size = 150818, upload-time = "2026-03-26T09:58:15.808Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.139.0"
 source = { registry = "https://pypi.org/simple" }
@@ -528,14 +615,17 @@ source = { virtual = "." }
 dependencies = [
     { name = "alembic" },
     { name = "asyncpg" },
+    { name = "bcrypt" },
     { name = "celery" },
     { name = "fastapi" },
     { name = "langgraph" },
     { name = "langgraph-checkpoint-postgres" },
+    { name = "passlib", extra = ["bcrypt"] },
     { name = "pgvector" },
     { name = "pydantic-settings" },
     { name = "pytest-asyncio" },
     { name = "python-dotenv" },
+    { name = "python-jose", extra = ["cryptography"] },
     { name = "redis" },
     { name = "sqlalchemy" },
     { name = "testcontainers" },
@@ -556,14 +646,17 @@ dev = [
 requires-dist = [
     { name = "alembic", specifier = ">=1.18.5" },
     { name = "asyncpg", specifier = ">=0.30.0" },
+    { name = "bcrypt", specifier = "==4.0.1" },
     { name = "celery", specifier = ">=5.4.0" },
     { name = "fastapi", specifier = ">=0.139.0" },
     { name = "langgraph", specifier = ">=1.2.11" },
     { name = "langgraph-checkpoint-postgres", specifier = ">=3.1.2" },
+    { name = "passlib", extras = ["bcrypt"], specifier = ">=1.7.4" },
     { name = "pgvector", specifier = ">=0.4.0" },
     { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "pytest-asyncio", specifier = ">=1.4.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
+    { name = "python-jose", extras = ["cryptography"], specifier = ">=3.3.0" },
     { name = "redis", specifier = ">=5.2.0" },
     { name = "sqlalchemy", specifier = ">=2.0.51" },
     { name = "testcontainers", extras = ["postgres"], specifier = ">=4.8.0" },
@@ -1685,6 +1778,20 @@ wheels = [
 ]
 
 [[package]]
+name = "passlib"
+version = "1.7.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/06/9da9ee59a67fae7761aab3ccc84fa4f3f33f125b370f1ccdb915bf967c11/passlib-1.7.4.tar.gz", hash = "sha256:defd50f72b65c5402ab2c573830a6978e5f202ad0d984793c8dde2c4152ebe04", size = 689844, upload-time = "2020-10-08T19:00:52.121Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/a4/ab6b7589382ca3df236e03faa71deac88cae040af60c071a78d254a62172/passlib-1.7.4-py2.py3-none-any.whl", hash = "sha256:aa6bca462b8d8bda89c70b382f0c298a20b5560af6cbfa2dce410c0a2fb669f1", size = 525554, upload-time = "2020-10-08T19:00:49.856Z" },
+]
+
+[package.optional-dependencies]
+bcrypt = [
+    { name = "bcrypt" },
+]
+
+[[package]]
 name = "pathspec"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1779,6 +1886,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/90/82/7a23d26039827ecd4ebe93905651029ddd307c5182ad59296dfb6f67b528/psycopg_pool-3.3.1.tar.gz", hash = "sha256:b10b10b7a175d5cc1592147dc5b7eec8a9e0834eb3ed2c4a92c858e2f51eb63c", size = 31661, upload-time = "2026-05-01T23:31:59.809Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/37/ed/89c2c620af0e1660354cd8aabf9f5b21f911597ce22acb37c805d6c86bc8/psycopg_pool-3.3.1-py3-none-any.whl", hash = "sha256:2af5b432941c4c9ad5c87b3fa410aec910ec8f7c122855897983a06c45f2e4b5", size = 40023, upload-time = "2026-05-01T23:31:53.136Z" },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
 ]
 
 [[package]]
@@ -1981,6 +2097,25 @@ wheels = [
 ]
 
 [[package]]
+name = "python-jose"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ecdsa" },
+    { name = "pyasn1" },
+    { name = "rsa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/77/3a1c9039db7124eb039772b935f2244fbb73fc8ee65b9acf2375da1c07bf/python_jose-3.5.0.tar.gz", hash = "sha256:fb4eaa44dbeb1c26dcc69e4bd7ec54a1cb8dd64d3b4d81ef08d90ff453f2b01b", size = 92726, upload-time = "2025-05-28T17:31:54.288Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/c3/0bd11992072e6a1c513b16500a5d07f91a24017c5909b02c72c62d7ad024/python_jose-3.5.0-py2.py3-none-any.whl", hash = "sha256:abd1202f23d34dfad2c3d28cb8617b90acf34132c7afd60abd0b0b7d3cb55771", size = 34624, upload-time = "2025-05-28T17:31:52.802Z" },
+]
+
+[package.optional-dependencies]
+cryptography = [
+    { name = "cryptography" },
+]
+
+[[package]]
 name = "pytz"
 version = "2026.3.post1"
 source = { registry = "https://pypi.org/simple" }
@@ -2103,6 +2238,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888, upload-time = "2023-05-01T04:11:33.229Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06", size = 54481, upload-time = "2023-05-01T04:11:28.427Z" },
+]
+
+[[package]]
+name = "rsa"
+version = "4.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034, upload-time = "2025-04-16T09:51:18.218Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696, upload-time = "2025-04-16T09:51:17.142Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -567,6 +567,15 @@ wheels = [
 ]
 
 [[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
 name = "docker"
 version = "7.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -590,6 +599,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/25/ca/8de7744cb3bc966c85430ca2d0fcaeea872507c6a4cf6e007f7fe269ed9d/ecdsa-0.19.2.tar.gz", hash = "sha256:62635b0ac1ca2e027f82122b5b81cb706edc38cd91c63dda28e4f3455a2bf930", size = 202432, upload-time = "2026-03-26T09:58:17.675Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/51/79/119091c98e2bf49e24ed9f3ae69f816d715d2904aefa6a2baa039a2ba0b0/ecdsa-0.19.2-py2.py3-none-any.whl", hash = "sha256:840f5dc5e375c68f36c1a7a5b9caad28f95daa65185c9253c0c08dd952bb7399", size = 150818, upload-time = "2026-03-26T09:58:15.808Z" },
+]
+
+[[package]]
+name = "email-validator"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
 ]
 
 [[package]]
@@ -622,6 +644,7 @@ dependencies = [
     { name = "langgraph-checkpoint-postgres" },
     { name = "passlib", extra = ["bcrypt"] },
     { name = "pgvector" },
+    { name = "pydantic", extra = ["email"] },
     { name = "pydantic-settings" },
     { name = "pytest-asyncio" },
     { name = "python-dotenv" },
@@ -653,6 +676,7 @@ requires-dist = [
     { name = "langgraph-checkpoint-postgres", specifier = ">=3.1.2" },
     { name = "passlib", extras = ["bcrypt"], specifier = ">=1.7.4" },
     { name = "pgvector", specifier = ">=0.4.0" },
+    { name = "pydantic", extras = ["email"] },
     { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "pytest-asyncio", specifier = ">=1.4.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
@@ -1919,6 +1943,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[package.optional-dependencies]
+email = [
+    { name = "email-validator" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What?
Added JWT authentication for the FinAgent API. Closes #97. Managers now authenticate via email/password and receive a Bearer token used to authorize all `/pipeline/*`, `/morning-notes/*`, and `/feedback` routes. The legacy `manager-id` header auth is removed. Includes migration, password hashing, JWT encode/decode, auth dependency, login/me endpoints, and full test coverage.

## Why?
FinAgent enforces strict multi-tenant RLS isolation — every query is scoped by `manager_id`. The previous `manager-id` header pattern was an unsafe trust-the-client model: any caller could impersonate any manager. JWT replaces it with a signed, short-lived token bound to an authenticated identity, so the API can trust `manager.id` from the dependency rather than user-supplied input.

## How?
- **Migration**: `6f6d0b6496b7_add_password_hash_to_managers.py` — adds `password_hash` column to `managers`.
- **`app/utils/security.py`**: `hash_password` / `verify_password` via bcrypt (passlib).
- **`app/core/security.py`**: `create_access_token` / `decode_access_token` using HS256, 30-min expiry, `manager_id` claim.
- **`app/services/auth.py`**: `AuthService.authenticate(email, password)` and `get_by_id`.
- **`app/api/routes/auth.py`**: `POST /auth/login` (returns token + manager), `GET /auth/me`.
- **`app/api/deps.py`**: `get_current_manager` — `HTTPBearer(auto_error=False)` + `decode_access_token` + DB lookup. Returns 401 for missing/invalid/expired tokens or unknown managers.
- **Wired into routes**: `pipeline.py`, `morning_notes.py` (list/detail/stream), `feedback.py`. `GET /health` stays public.
- **Error**: `InvalidTokenError` added to `app/api/errors.py`; handled with try/except → 401.
- **Tests**: `tests/unit/test_auth_deps.py` (10 tests), `tests/integration/test_auth.py` (7 tests). Existing tests updated to use Bearer tokens via `_make_token` helper.

Design call: `decode_access_token` returns `None` on error rather than raising; `get_current_manager` converts to `HTTPException(401)`. This keeps a single failure boundary in the dependency layer.

## Testing?
All 150 tests pass:
```
uv run pytest tests/ -v
```
- 10 unit tests for JWT create/decode + security constants
- 7 integration tests for login + /me (valid/invalid/nonexistent/missing fields)
- 5 updated integration test files now use Bearer tokens (`test_morning_notes.py`, `test_feedback.py`, `test_pipeline.py`, `test_auth.py`)
- RLS isolation test uses a valid token from a different manager → confirms 404, not 200

Edge case covered: a manager with a valid token but no row in `morning_notes` for the requested `note_id` returns 404 (route type fixed from `note_id: str` to `note_id: int` to match `MorningNote.id`).

## Anything Else?
- ADR-017 plans a hybrid JWT + refresh cookie model for Phase 3/4 — current 30-min expiry requires re-login.
- `sub` claim currently holds the email; the dependency uses `manager_id`. Minor inconsistency — could standardize to UUID/email later.
- `get_current_manager` does a DB lookup on every authenticated request. Fine for now; consider a small cache if latency becomes an issue.
- Test fixture hardcodes `alice123` / `bob123` passwords via `hash_password()` in `conftest.py`. If the fixture changes, these tests break — worth isolating into a seed helper in a future cleanup.