### PR TITLE
feat(issue-98): Closes #98 — standardized ApiError contract + tests

### DIFF
--- a/app/api/deps.py
+++ b/app/api/deps.py
@@ -1,5 +1,5 @@
 from typing import Annotated
-from fastapi import Depends, HTTPException, status
+from fastapi import Depends, status
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -7,7 +7,7 @@ from app.db.session import get_read_session
 from app.services.analysis import AnalysisService
 from app.services.auth import AuthService
 from app.core.security import decode_access_token
-from app.api.errors import InvalidTokenError
+from app.api.errors import ApiError, ErrorCodes, InvalidTokenError
 from app.db.models import Manager
 
 
@@ -19,20 +19,20 @@ async def get_current_manager(
         session: Annotated[AsyncSession, Depends(get_read_session)]
 ) -> Manager:
     if not credentials:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
+        raise ApiError(status_code=status.HTTP_401_UNAUTHORIZED, code=ErrorCodes.UNAUTHORIZED, message="Not authenticated")
 
     try:
         payload = decode_access_token(credentials.credentials)
     except InvalidTokenError:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid or expired token")
+        raise ApiError(status_code=status.HTTP_401_UNAUTHORIZED, code=ErrorCodes.UNAUTHORIZED, message="Invalid or expired token")
 
     if not payload or "manager_id" not in payload:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+        raise ApiError(status_code=status.HTTP_401_UNAUTHORIZED, code=ErrorCodes.UNAUTHORIZED, message="Invalid token")
 
     auth_service = AuthService(session)
     manager = await auth_service.get_by_id(payload["manager_id"])
     if not manager:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Manager not found")
+        raise ApiError(status_code=status.HTTP_401_UNAUTHORIZED, code=ErrorCodes.UNAUTHORIZED, message="Manager not found")
     
     return manager
 

--- a/app/api/errors.py
+++ b/app/api/errors.py
@@ -1,3 +1,11 @@
+from datetime import datetime, UTC
+from enum import StrEnum
+from typing import Any, Optional, cast
+
+from fastapi import HTTPException
+from pydantic import BaseModel, Field
+
+
 class PipelineError(Exception):
     """Base for all pipeline-domain errors.
 
@@ -19,3 +27,32 @@ class InvalidTokenError(Exception):
     def __init__(self, message: str = "Invalid or expired token"):
         self.message = message
         super().__init__(self.message)
+
+
+class ErrorCodes(StrEnum):
+    MISSING_HEADER = "MISSING_HEADER"
+    INVALID_HEADER = "INVALID_HEADER"
+    VALIDATION_ERROR = "VALIDATION_ERROR"
+    NOT_FOUND = "NOT_FOUND"
+    RLS_VIOLATION = "RLS_VIOLATION"
+    CONFLICT = "CONFLICT"
+    IDEMPOTENCY_KEY_EXISTS = "IDEMPOTENCY_KEY_EXISTS"
+    UNAUTHORIZED = "UNAUTHORIZED"
+
+    INTERNAL_ERROR = "INTERNAL_ERROR"
+    SERVICE_UNAVAILABLE = "SERVICE_UNAVAILABLE"
+    EXTERNAL_API_ERROR = "EXTERNAL_API_ERROR"
+    DATABASE_ERROR = "DATABASE_ERROR"
+
+class ApiErrorDetail(BaseModel):
+    code: str
+    message: str
+    details: Optional[dict[str, list[str]]] = None
+    timestamp: str = Field(default_factory=lambda: datetime.now(UTC).isoformat())
+    path: Optional[str] = None
+
+
+class ApiError(HTTPException):
+    def __init__(self, status_code: int, code: str, message: str, details: Optional[dict[str, list[str]]] = None, path: Optional[str] = None):
+        self.status_code = status_code
+        self.detail = cast(Any, ApiErrorDetail(code=code, message=message, details=details, path=path))

--- a/app/api/errors.py
+++ b/app/api/errors.py
@@ -66,20 +66,23 @@ class ApiError(HTTPException):
 
 logger = logging.getLogger(__name__)
 
-def _json_response_from_api_error(api_error: ApiError, request) -> JSONResponse:
+
+def json_response_from_api_error(api_error: ApiError, request) -> JSONResponse:
     detail = cast(ApiErrorDetail, api_error.detail)
-    detail.path = request.url.path
+    payload = detail.model_dump()
+    if payload.get("path") is None:
+        payload["path"] = request.url.path
     return JSONResponse(
-        content=detail.model_dump(),
+        content=payload,
         status_code=api_error.status_code
     )
 
 
-def _build_dict_of_lists(errors) -> dict[str, list[str]]:
+def build_dict_of_lists(errors) -> dict[str, list[str]]:
     details: dict[str, list[str]] = {}
     for err in errors:
-        loc = err["loc"]
-        field = loc[-1]
+        loc = err.get("loc", ())
+        field = loc[-1] if loc else "_root"
         msg = err["msg"]
         if field not in details:
             details[field] = []
@@ -88,13 +91,13 @@ def _build_dict_of_lists(errors) -> dict[str, list[str]]:
     return details
 
 
-_ERROR_MAP: dict[str, tuple[int, ErrorCodes, str]] = {
-    "MorningNoteNotFound": (
+_ERROR_MAP: dict[type[PipelineError], tuple[int, ErrorCodes, str]] = {
+    MorningNoteNotFound: (
         status.HTTP_404_NOT_FOUND, ErrorCodes.NO_ACTIVE_RUN,
         "Morning note not found in current stream.",
     ),
-    "InvalidTriggerPayload": (
-        status.HTTP_422_UNPROCESSABLE_ENTITY, ErrorCodes.INVALID_TRIGGER_PAYLOAD,
+    InvalidTriggerPayload: (
+        status.HTTP_422_UNPROCESSABLE_CONTENT, ErrorCodes.INVALID_TRIGGER_PAYLOAD,
         "Payload well-formed but breaks logic",
     ),
 }
@@ -105,7 +108,7 @@ def _build_api_error(status_code: int, code: ErrorCodes, message: str) -> ApiErr
 
 
 def translate(exc: PipelineError) -> ApiError:
-    spec = _ERROR_MAP.get(type(exc).__name__)
+    spec = _ERROR_MAP.get(type(exc))
     if spec is not None:
         status_code, code, message = spec
         return _build_api_error(status_code, code, message)

--- a/app/api/errors.py
+++ b/app/api/errors.py
@@ -1,8 +1,10 @@
+import logging
 from datetime import datetime, UTC
 from enum import StrEnum
 from typing import Any, Optional, cast
 
-from fastapi import HTTPException
+from fastapi import HTTPException, status
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
 
@@ -23,6 +25,7 @@ class InvalidTriggerPayload(PipelineError):
     pydantic's structural checks (e.g., company_id not in manager's book).
     """
 
+
 class InvalidTokenError(Exception):
     def __init__(self, message: str = "Invalid or expired token"):
         self.message = message
@@ -38,11 +41,14 @@ class ErrorCodes(StrEnum):
     CONFLICT = "CONFLICT"
     IDEMPOTENCY_KEY_EXISTS = "IDEMPOTENCY_KEY_EXISTS"
     UNAUTHORIZED = "UNAUTHORIZED"
+    NO_ACTIVE_RUN = "NO_ACTIVE_RUN"
+    INVALID_TRIGGER_PAYLOAD = "INVALID_TRIGGER_PAYLOAD"
 
     INTERNAL_ERROR = "INTERNAL_ERROR"
     SERVICE_UNAVAILABLE = "SERVICE_UNAVAILABLE"
     EXTERNAL_API_ERROR = "EXTERNAL_API_ERROR"
     DATABASE_ERROR = "DATABASE_ERROR"
+
 
 class ApiErrorDetail(BaseModel):
     code: str
@@ -56,3 +62,64 @@ class ApiError(HTTPException):
     def __init__(self, status_code: int, code: str, message: str, details: Optional[dict[str, list[str]]] = None, path: Optional[str] = None):
         self.status_code = status_code
         self.detail = cast(Any, ApiErrorDetail(code=code, message=message, details=details, path=path))
+
+
+logger = logging.getLogger(__name__)
+
+def _json_response_from_api_error(api_error: ApiError, request) -> JSONResponse:
+    detail = cast(ApiErrorDetail, api_error.detail)
+    detail.path = request.url.path
+    return JSONResponse(
+        content=detail.model_dump(),
+        status_code=api_error.status_code
+    )
+
+
+def _build_dict_of_lists(errors) -> dict[str, list[str]]:
+    details: dict[str, list[str]] = {}
+    for err in errors:
+        loc = err["loc"]
+        field = loc[-1]
+        msg = err["msg"]
+        if field not in details:
+            details[field] = []
+        details[field].append(msg)
+
+    return details
+
+
+_ERROR_MAP: dict[str, tuple[int, ErrorCodes, str]] = {
+    "MorningNoteNotFound": (
+        status.HTTP_404_NOT_FOUND, ErrorCodes.NO_ACTIVE_RUN,
+        "Morning note not found in current stream.",
+    ),
+    "InvalidTriggerPayload": (
+        status.HTTP_422_UNPROCESSABLE_ENTITY, ErrorCodes.INVALID_TRIGGER_PAYLOAD,
+        "Payload well-formed but breaks logic",
+    ),
+}
+
+
+def _build_api_error(status_code: int, code: ErrorCodes, message: str) -> ApiError:
+    return ApiError(status_code=status_code, code=code, message=message)
+
+
+def translate(exc: PipelineError) -> ApiError:
+    spec = _ERROR_MAP.get(type(exc).__name__)
+    if spec is not None:
+        status_code, code, message = spec
+        return _build_api_error(status_code, code, message)
+
+    logger.exception(
+        "Unmapped PipelineError subclass escaped to HTTP boundary",
+        extra={
+            "exc_type": type(exc).__name__,
+            "exc_args": exc.args,
+        },
+    )
+
+    return _build_api_error(
+        status.HTTP_500_INTERNAL_SERVER_ERROR,
+        ErrorCodes.INTERNAL_ERROR,
+        "Internal server error",
+    )

--- a/app/api/routes/auth.py
+++ b/app/api/routes/auth.py
@@ -1,6 +1,6 @@
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, status
 from pydantic import BaseModel, EmailStr
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -8,6 +8,7 @@ from app.db.session import get_session
 from app.services.auth import AuthService
 from app.core.security import create_access_token
 from app.api.deps import get_current_manager
+from app.api.errors import ApiError, ErrorCodes
 from app.db.models import Manager
 
 
@@ -17,6 +18,7 @@ router = APIRouter(prefix="/auth", tags=["auth"])
 class LoginRequest(BaseModel):
     email: EmailStr
     password: str
+
 
 class TokenResponse(BaseModel):
     access_token: str
@@ -32,7 +34,7 @@ async def login(
     auth_service = AuthService(session)
     manager = await auth_service.authenticate(data.email, data.password)
     if not manager:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+        raise ApiError(status_code=status.HTTP_401_UNAUTHORIZED, code=ErrorCodes.UNAUTHORIZED, message="Invalid credentials")
 
     token = create_access_token({"sub": manager.email, "manager_id": manager.id})
     return TokenResponse(

--- a/app/api/routes/feedback.py
+++ b/app/api/routes/feedback.py
@@ -1,11 +1,12 @@
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, status
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.models import Feedback, Manager
 from app.api.deps import get_current_manager
+from app.api.errors import ApiError, ErrorCodes
 from app.db.session import get_session
 from app.schemas.feedback import FeedbackCreate, FeedbackResponse
 
@@ -34,7 +35,7 @@ async def create_feedback(
         )
         row = result.first()
         if row is None:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Morning note not found")
+            raise ApiError(status_code=status.HTTP_404_NOT_FOUND, code=ErrorCodes.NOT_FOUND, message="Morning note not found")
 
         result = await session.execute(
             text(
@@ -51,7 +52,7 @@ async def create_feedback(
             }
         )
         if result.first() is not None:
-            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="This feedback already exists.")
+            raise ApiError(status_code=status.HTTP_409_CONFLICT, code=ErrorCodes.CONFLICT, message="This feedback already exists.")
 
         feedback = Feedback(
             morning_note_id=note_id,

--- a/app/api/routes/morning_notes.py
+++ b/app/api/routes/morning_notes.py
@@ -2,14 +2,14 @@ import json
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, status
 from fastapi.responses import StreamingResponse
 
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from app.api.errors import MorningNoteNotFound
+from app.api.errors import ApiError, ErrorCodes, MorningNoteNotFound
 from app.api.deps import get_current_manager
 from app.db.session import get_session
 from app.db.models import MorningNote, Manager
@@ -56,7 +56,7 @@ async def stream_morning_note(
         note = result.scalar_one_or_none()
 
         if note is None:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Morning note not found")
+            raise ApiError(status_code=status.HTTP_404_NOT_FOUND, code=ErrorCodes.NOT_FOUND, message="Morning note not found")
         
     run_id = _PIPELINE_REGISTRY.get(str(note_id))
     if run_id is None:
@@ -101,7 +101,7 @@ async def read_morning_note(
 
         note = result.scalar_one_or_none()
         if note is None:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Morning note not found")
+            raise ApiError(status_code=status.HTTP_404_NOT_FOUND, code=ErrorCodes.NOT_FOUND, message="Morning note not found")
 
         response = {
             "id": note.id,

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,9 @@
 from contextlib import asynccontextmanager
+import logging
+from typing import cast
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Response, status
+from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 
 from sqlalchemy import text
@@ -12,7 +15,7 @@ from app.api.routes.auth import router as auth_router
 from app.api.routes.morning_notes import router as morning_notes_router
 from app.api.routes.feedback import router as feedback_router
 from app.api.routes.pipeline import router as pipeline_router
-from app.api.errors import MorningNoteNotFound
+from app.api.errors import ApiError, ApiErrorDetail, ErrorCodes, MorningNoteNotFound
 
 
 @asynccontextmanager
@@ -24,6 +27,7 @@ async def lifespan(app: FastAPI):
 
 
 app = FastAPI(title="FinAgent", lifespan=lifespan)
+logger = logging.getLogger(__name__)
 
 
 app.add_middleware(CorrelationMiddleware)
@@ -49,4 +53,58 @@ async def morning_note_not_found_handler(request, exc):
     return JSONResponse(
         status_code=404,
         content={"detail": f"morning note {exc.args[0]!r} not found"}
+    )
+
+
+@app.exception_handler(ApiError)
+async def api_error_handler(request, exc):
+    detail = cast(ApiErrorDetail, exc.detail)
+    detail.path = request.url.path
+
+    return JSONResponse(
+        content=detail.model_dump(),
+        status_code=exc.status_code
+    )
+
+
+@app.exception_handler(Exception)
+async def error_handler(request, exc):
+    logger.exception("Unhandled error", extra={"url_path": request.url.path})
+    api_error = ApiError(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        code=ErrorCodes.INTERNAL_ERROR,
+        message="Internal server error"
+    )
+    detail = cast(ApiErrorDetail, api_error.detail)
+    detail.path = request.url.path
+
+    return JSONResponse(
+        content=detail.model_dump(),
+        status_code=api_error.status_code
+    )
+
+
+def _build_dict_of_lists(errors):
+    details: dict[str, list[str]] = {}
+    for err in errors:
+        loc = err["loc"]
+        field = loc[-1]
+        msg = err["msg"]
+        if field not in details:
+            details[field] = []
+        details[field].append(msg)
+
+    return details
+
+
+@app.exception_handler(RequestValidationError)
+async def validation_handler(request, exc: RequestValidationError) -> Response:
+    details = _build_dict_of_lists(exc.errors)
+    api_error = ApiError(422, ErrorCodes.VALIDATION_ERROR, "Validation error", details=details)
+    detail = cast(ApiErrorDetail, api_error.detail)
+    detail.path = request.url.path
+
+    return JSONResponse(
+        content=detail.model_dump(),
+        status_code=api_error.status_code
     )

--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,7 @@
 from contextlib import asynccontextmanager
 import logging
 
-from fastapi import FastAPI, Response, status
+from fastapi import FastAPI, Response, Request, status
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 
@@ -18,8 +18,8 @@ from app.api.errors import (
     ApiError,
     ErrorCodes,
     PipelineError,
-    _build_dict_of_lists,
-    _json_response_from_api_error,
+    build_dict_of_lists,
+    json_response_from_api_error,
     translate,
 )
 
@@ -44,18 +44,24 @@ app.include_router(feedback_router)
 
 
 @app.get("/health")
-async def health() -> JSONResponse:
+async def health(request: Request) -> Response:
     try:
         async with engine.begin() as conn:
             await conn.execute(text("SELECT 1"))
         return JSONResponse({"status": "ok", "db": "ok"})
     except SQLAlchemyError:
-        return JSONResponse({"status": "degraded", "db": "unreachable"}, status_code=503)
+        api_error = ApiError(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            code=ErrorCodes.SERVICE_UNAVAILABLE,
+            message="Service degraded: database unreachable",
+            details={"db": ["unreachable"]},
+        )
+        return json_response_from_api_error(api_error, request)
 
 
 @app.exception_handler(ApiError)
 async def api_error_handler(request, exc):
-    return _json_response_from_api_error(exc, request)
+    return json_response_from_api_error(exc, request)
 
 
 @app.exception_handler(Exception)
@@ -66,17 +72,22 @@ async def error_handler(request, exc):
         code=ErrorCodes.INTERNAL_ERROR,
         message="Internal server error"
     )
-    return _json_response_from_api_error(api_error, request)
+    return json_response_from_api_error(api_error, request)
 
 
 @app.exception_handler(RequestValidationError)
 async def validation_handler(request, exc: RequestValidationError) -> Response:
-    details = _build_dict_of_lists(exc.errors())
-    api_error = ApiError(422, ErrorCodes.VALIDATION_ERROR, "Validation error", details=details)
-    return _json_response_from_api_error(api_error, request)
+    details = build_dict_of_lists(exc.errors())
+    api_error = ApiError(
+        status.HTTP_422_UNPROCESSABLE_CONTENT,
+        ErrorCodes.VALIDATION_ERROR,
+        "Validation error",
+        details=details,
+    )
+    return json_response_from_api_error(api_error, request)
 
 
 @app.exception_handler(PipelineError)
 async def pipeline_error_handler(request, exc):
     api_error = translate(exc)
-    return _json_response_from_api_error(api_error, request)
+    return json_response_from_api_error(api_error, request)

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,5 @@
 from contextlib import asynccontextmanager
 import logging
-from typing import cast
 
 from fastapi import FastAPI, Response, status
 from fastapi.exceptions import RequestValidationError
@@ -15,7 +14,14 @@ from app.api.routes.auth import router as auth_router
 from app.api.routes.morning_notes import router as morning_notes_router
 from app.api.routes.feedback import router as feedback_router
 from app.api.routes.pipeline import router as pipeline_router
-from app.api.errors import ApiError, ApiErrorDetail, ErrorCodes, MorningNoteNotFound
+from app.api.errors import (
+    ApiError,
+    ErrorCodes,
+    PipelineError,
+    _build_dict_of_lists,
+    _json_response_from_api_error,
+    translate,
+)
 
 
 @asynccontextmanager
@@ -47,24 +53,9 @@ async def health() -> JSONResponse:
         return JSONResponse({"status": "degraded", "db": "unreachable"}, status_code=503)
 
 
-@app.exception_handler(MorningNoteNotFound)
-async def morning_note_not_found_handler(request, exc):
-    # TODO(#19): re-evaluate log level when this becomes a polling hot path
-    return JSONResponse(
-        status_code=404,
-        content={"detail": f"morning note {exc.args[0]!r} not found"}
-    )
-
-
 @app.exception_handler(ApiError)
 async def api_error_handler(request, exc):
-    detail = cast(ApiErrorDetail, exc.detail)
-    detail.path = request.url.path
-
-    return JSONResponse(
-        content=detail.model_dump(),
-        status_code=exc.status_code
-    )
+    return _json_response_from_api_error(exc, request)
 
 
 @app.exception_handler(Exception)
@@ -75,36 +66,17 @@ async def error_handler(request, exc):
         code=ErrorCodes.INTERNAL_ERROR,
         message="Internal server error"
     )
-    detail = cast(ApiErrorDetail, api_error.detail)
-    detail.path = request.url.path
-
-    return JSONResponse(
-        content=detail.model_dump(),
-        status_code=api_error.status_code
-    )
-
-
-def _build_dict_of_lists(errors):
-    details: dict[str, list[str]] = {}
-    for err in errors:
-        loc = err["loc"]
-        field = loc[-1]
-        msg = err["msg"]
-        if field not in details:
-            details[field] = []
-        details[field].append(msg)
-
-    return details
+    return _json_response_from_api_error(api_error, request)
 
 
 @app.exception_handler(RequestValidationError)
 async def validation_handler(request, exc: RequestValidationError) -> Response:
     details = _build_dict_of_lists(exc.errors)
     api_error = ApiError(422, ErrorCodes.VALIDATION_ERROR, "Validation error", details=details)
-    detail = cast(ApiErrorDetail, api_error.detail)
-    detail.path = request.url.path
+    return _json_response_from_api_error(api_error, request)
 
-    return JSONResponse(
-        content=detail.model_dump(),
-        status_code=api_error.status_code
-    )
+
+@app.exception_handler(PipelineError)
+async def pipeline_error_handler(request, exc):
+    api_error = translate(exc)
+    return _json_response_from_api_error(api_error, request)

--- a/app/main.py
+++ b/app/main.py
@@ -71,7 +71,7 @@ async def error_handler(request, exc):
 
 @app.exception_handler(RequestValidationError)
 async def validation_handler(request, exc: RequestValidationError) -> Response:
-    details = _build_dict_of_lists(exc.errors)
+    details = _build_dict_of_lists(exc.errors())
     api_error = ApiError(422, ErrorCodes.VALIDATION_ERROR, "Validation error", details=details)
     return _json_response_from_api_error(api_error, request)
 

--- a/tests/integration/test_errors.py
+++ b/tests/integration/test_errors.py
@@ -1,9 +1,11 @@
 from datetime import datetime
 
 from httpx import ASGITransport, AsyncClient
-from starlette.routing import Route
 import pytest
 
+from fastapi import FastAPI, Request
+
+from app.api.errors import ApiError, ErrorCodes, json_response_from_api_error
 from app.core.security import create_access_token
 from app.main import app
 
@@ -100,7 +102,16 @@ async def test_nonexistent_note_returns_not_found_and_shape(
     _assert_shape(body)
 
 
-async def _boom(request):
+async def _error_handler(request, exc):
+    api_error = ApiError(
+        status_code=500,
+        code=ErrorCodes.INTERNAL_ERROR,
+        message="Internal server error",
+    )
+    return json_response_from_api_error(api_error, request)
+
+
+async def _boom(request: Request):
     raise RuntimeError("boom")
 
 
@@ -108,18 +119,17 @@ async def _boom(request):
 async def test_unhandled_exception_returns_500_no_traceback(
     bound_engine: None, finagent_app_role: None
 ) -> None:
-    route = Route("/_test/boom", _boom, methods=["GET"])
-    app.router.routes.append(route)
-    try:
-        transport = ASGITransport(app=app, raise_app_exceptions=False)
-        async with AsyncClient(transport=transport, base_url="http://test") as client:
-            resp = await client.get("/_test/boom")
+    isolated = FastAPI()
+    isolated.add_exception_handler(Exception, _error_handler)
+    isolated.add_api_route("/_test/boom", _boom, methods=["GET"])
 
-        assert resp.status_code == 500
-        body = resp.json()
-        assert body["code"] == "INTERNAL_ERROR"
-        assert "Traceback" not in resp.text
-        assert "Stack" not in resp.text
-        _assert_shape(body)
-    finally:
-        app.router.routes.remove(route)
+    transport = ASGITransport(app=isolated, raise_app_exceptions=False)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/_test/boom")
+
+    assert resp.status_code == 500
+    body = resp.json()
+    assert body["code"] == "INTERNAL_ERROR"
+    assert "Traceback" not in resp.text
+    assert "Stack" not in resp.text
+    _assert_shape(body)

--- a/tests/integration/test_errors.py
+++ b/tests/integration/test_errors.py
@@ -1,0 +1,125 @@
+from datetime import datetime
+
+from httpx import ASGITransport, AsyncClient
+from starlette.routing import Route
+import pytest
+
+from app.core.security import create_access_token
+from app.main import app
+
+
+def _make_token(manager_id: int) -> str:
+    return create_access_token({"sub": str(manager_id), "manager_id": manager_id})
+
+
+def _assert_shape(body: dict) -> None:
+    assert "code" in body
+    assert "message" in body
+    assert "path" in body
+    assert "timestamp" in body
+    dt = datetime.fromisoformat(body["timestamp"])
+    offset = dt.utcoffset()
+    assert offset is not None
+    assert offset.total_seconds() == 0
+
+
+async def _first_note_id(client: AsyncClient, manager_id: int) -> int:
+    resp = await client.get(
+        "/morning-notes", headers={"Authorization": f"Bearer {_make_token(manager_id)}"}
+    )
+    assert resp.status_code == 200
+    notes = resp.json()
+    assert notes
+    return notes[0]["id"]
+
+
+@pytest.mark.asyncio
+async def test_missing_header_returns_401_and_shape(
+    bound_engine: None, finagent_app_role: None
+) -> None:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/morning-notes/1/feedback")
+    assert resp.status_code == 401
+    _assert_shape(resp.json())
+
+
+@pytest.mark.asyncio
+async def test_validation_error_details_grouped_by_field(
+    bound_engine: None, finagent_app_role: None
+) -> None:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        note_id = await _first_note_id(client, 2)
+        resp = await client.post(
+            f"/morning-notes/{note_id}/feedback",
+            headers={"Authorization": f"Bearer {_make_token(2)}"},
+            json={"justification": "Strong fundamentals"},
+        )
+
+    assert resp.status_code == 422
+    body = resp.json()
+    assert body["code"] == "VALIDATION_ERROR"
+    assert "action" in body["details"]
+    assert isinstance(body["details"]["action"], list)
+    _assert_shape(body)
+
+
+@pytest.mark.asyncio
+async def test_registry_miss_returns_no_active_run(
+    bound_engine: None, finagent_app_role: None
+) -> None:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        note_id = await _first_note_id(client, 2)
+        resp = await client.get(
+            f"/morning-notes/{note_id}/stream",
+            headers={"Authorization": f"Bearer {_make_token(2)}"},
+        )
+
+    assert resp.status_code == 404
+    body = resp.json()
+    assert body["code"] == "NO_ACTIVE_RUN"
+    _assert_shape(body)
+
+
+@pytest.mark.asyncio
+async def test_nonexistent_note_returns_not_found_and_shape(
+    bound_engine: None, finagent_app_role: None
+) -> None:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(
+            "/morning-notes/999999999/stream",
+            headers={"Authorization": f"Bearer {_make_token(2)}"},
+        )
+
+    assert resp.status_code == 404
+    body = resp.json()
+    assert body["code"] == "NOT_FOUND"
+    _assert_shape(body)
+
+
+async def _boom(request):
+    raise RuntimeError("boom")
+
+
+@pytest.mark.asyncio
+async def test_unhandled_exception_returns_500_no_traceback(
+    bound_engine: None, finagent_app_role: None
+) -> None:
+    route = Route("/_test/boom", _boom, methods=["GET"])
+    app.router.routes.append(route)
+    try:
+        transport = ASGITransport(app=app, raise_app_exceptions=False)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/_test/boom")
+
+        assert resp.status_code == 500
+        body = resp.json()
+        assert body["code"] == "INTERNAL_ERROR"
+        assert "Traceback" not in resp.text
+        assert "Stack" not in resp.text
+        _assert_shape(body)
+    finally:
+        app.router.routes.remove(route)

--- a/tests/integration/test_feedback.py
+++ b/tests/integration/test_feedback.py
@@ -85,7 +85,7 @@ async def test_create_feedback_valid_manager_non_existent_note_id_returns_404(bo
         )
 
         assert resp.status_code == 404
-        assert resp.json() == {"detail": "Morning note not found"}
+        assert resp.json()["code"] == "NOT_FOUND"
 
 
 @pytest.mark.asyncio
@@ -107,7 +107,7 @@ async def test_manager_a_posts_on_manager_b_note_returns_404(bound_engine: None,
         )
         
         assert resp.status_code == 404
-        assert resp.json() == {"detail": "Morning note not found"}
+        assert resp.json()["code"] == "NOT_FOUND"
 
 
 @pytest.mark.asyncio
@@ -127,6 +127,8 @@ async def test_create_feedback_missing_fields_returns_422(bound_engine: None, fi
         )
 
         assert resp.status_code == 422
+        assert resp.json()["code"] == "VALIDATION_ERROR"
+        assert "action" in resp.json()["details"]
 
 
 @pytest.mark.asyncio
@@ -147,7 +149,8 @@ async def test_create_feedback_invalid_action_returns_422(bound_engine: None, fi
         )
 
         assert resp.status_code == 422
-        assert resp.json()["detail"][0]["msg"] == "Input should be 'buy', 'sell' or 'keep'"
+        assert resp.json()["code"] == "VALIDATION_ERROR"
+        assert "action" in resp.json()["details"]
 
 
 @pytest.mark.asyncio
@@ -168,6 +171,8 @@ async def test_create_feedback_short_justification_422(bound_engine: None, finag
         )
 
         assert resp.status_code == 422
+        assert resp.json()["code"] == "VALIDATION_ERROR"
+        assert "justification" in resp.json()["details"]
 
 
 @pytest.mark.asyncio
@@ -189,4 +194,4 @@ async def test_create_duplicated_feedback_returns_409(bound_engine: None, finage
         )
 
         assert resp.status_code == 409
-        assert resp.json() == {'detail': 'This feedback already exists.'}
+        assert resp.json()["code"] == "CONFLICT"

--- a/tests/integration/test_health.py
+++ b/tests/integration/test_health.py
@@ -25,4 +25,8 @@ async def test_health_returns_503_when_db_raises(monkeypatch: pytest.MonkeyPatch
 
 
     assert resp.status_code == 503
-    assert resp.json() == {"status": "degraded", "db": "unreachable"}
+    body = resp.json()
+    assert body["code"] == "SERVICE_UNAVAILABLE"
+    assert body["details"] == {"db": ["unreachable"]}
+    assert "timestamp" in body
+    assert body["path"] == "/health"

--- a/tests/integration/test_morning_notes.py
+++ b/tests/integration/test_morning_notes.py
@@ -94,7 +94,7 @@ async def test_read_morning_notes_rls_isolation_returns_404(bound_engine: None, 
         )
 
         assert resp.status_code == 404
-        assert resp.json() == {"detail": "Morning note not found"}
+        assert resp.json()["code"] == "NOT_FOUND"
 
 
 @pytest.mark.asyncio
@@ -109,4 +109,4 @@ async def test_read_morning_notes_nonexistent_note_returns_404(bound_engine: Non
         )
 
         assert resp.status_code == 404
-        assert resp.json() == {"detail": "Morning note not found"}
+        assert resp.json()["code"] == "NOT_FOUND"

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -1,0 +1,94 @@
+import json
+from typing import cast
+
+import pytest
+
+from app.api.errors import (
+    ApiError,
+    ApiErrorDetail,
+    ErrorCodes,
+    InvalidTriggerPayload,
+    MorningNoteNotFound,
+    PipelineError,
+    _build_dict_of_lists,
+    _json_response_from_api_error,
+    translate,
+)
+
+
+class UnregisteredPipelineError(PipelineError):
+    pass
+
+
+def _det(api_error: ApiError) -> ApiErrorDetail:
+    return cast(ApiErrorDetail, api_error.detail)
+
+
+@pytest.mark.parametrize(
+    ("exc", "expected_status", "expected_code"),
+    [
+        (MorningNoteNotFound(), 404, ErrorCodes.NO_ACTIVE_RUN),
+        (InvalidTriggerPayload(), 422, ErrorCodes.INVALID_TRIGGER_PAYLOAD),
+    ],
+)
+def test_translate_known_subclass_mapping(exc, expected_status, expected_code) -> None:
+    api_error = translate(exc)
+
+    assert isinstance(api_error, ApiError)
+    assert api_error.status_code == expected_status
+    assert _det(api_error).code == expected_code
+
+
+def test_translate_default_logs_and_returns_500(caplog) -> None:
+    exc = UnregisteredPipelineError("boom")
+
+    api_error = translate(exc)
+
+    assert api_error.status_code == 500
+    assert _det(api_error).code == ErrorCodes.INTERNAL_ERROR
+    assert "Unmapped PipelineError subclass escaped to HTTP boundary" in caplog.text
+    assert any(rec.exc_type == "UnregisteredPipelineError" for rec in caplog.records)
+
+
+def test_translate_base_pipeline_error_defaults_to_500(caplog) -> None:
+    api_error = translate(PipelineError("bare"))
+
+    assert api_error.status_code == 500
+    assert _det(api_error).code == ErrorCodes.INTERNAL_ERROR
+
+
+def test_build_dict_of_lists_groups_by_field() -> None:
+    errors = [
+        {"loc": ("body", "action"), "msg": "field required"},
+        {"loc": ("body", "action"), "msg": "unexpected value"},
+        {"loc": ("body", "justification"), "msg": "too short"},
+    ]
+
+    details = _build_dict_of_lists(errors)
+
+    assert details == {
+        "action": ["field required", "unexpected value"],
+        "justification": ["too short"],
+    }
+
+
+def test_json_response_from_api_error_backfills_path_and_serializes_shape() -> None:
+    api_error = ApiError(
+        status_code=422,
+        code=ErrorCodes.VALIDATION_ERROR,
+        message="Validation error",
+        details={"action": ["field required"]},
+    )
+
+    class FakeRequest:
+        url = type("URL", (), {"path": "/morning-notes/n/1/feedback"})()
+
+    response = _json_response_from_api_error(api_error, FakeRequest())
+
+    body = json.loads(str(response.body, "utf-8"))
+    assert response.status_code == 422
+    assert body["code"] == "VALIDATION_ERROR"
+    assert body["message"] == "Validation error"
+    assert body["details"] == {"action": ["field required"]}
+    assert body["path"] == "/morning-notes/n/1/feedback"
+    assert "timestamp" in body

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -10,8 +10,8 @@ from app.api.errors import (
     InvalidTriggerPayload,
     MorningNoteNotFound,
     PipelineError,
-    _build_dict_of_lists,
-    _json_response_from_api_error,
+    build_dict_of_lists,
+    json_response_from_api_error,
     translate,
 )
 
@@ -64,12 +64,20 @@ def test_build_dict_of_lists_groups_by_field() -> None:
         {"loc": ("body", "justification"), "msg": "too short"},
     ]
 
-    details = _build_dict_of_lists(errors)
+    details = build_dict_of_lists(errors)
 
     assert details == {
         "action": ["field required", "unexpected value"],
         "justification": ["too short"],
     }
+
+
+def test_build_dict_of_lists_handles_empty_loc() -> None:
+    errors = [{"msg": "root-level failure"}]
+
+    details = build_dict_of_lists(errors)
+
+    assert details == {"_root": ["root-level failure"]}
 
 
 def test_json_response_from_api_error_backfills_path_and_serializes_shape() -> None:
@@ -83,7 +91,7 @@ def test_json_response_from_api_error_backfills_path_and_serializes_shape() -> N
     class FakeRequest:
         url = type("URL", (), {"path": "/morning-notes/n/1/feedback"})()
 
-    response = _json_response_from_api_error(api_error, FakeRequest())
+    response = json_response_from_api_error(api_error, FakeRequest())
 
     body = json.loads(str(response.body, "utf-8"))
     assert response.status_code == 422


### PR DESCRIPTION
## What this PR does

- Replaces the ad-hoc `{"detail": ...}` error responses with a standardized `ApiError` contract: `{code, message, details?, timestamp, path}`.
- Adds `app/api/errors.py` — `PipelineError` hierarchy, `ErrorCodes`, `ApiError`/`ApiErrorDetail` types, and the translator/helpers (`translate`, `_build_dict_of_lists`, `_json_response_from_api_error`) moved out of `main.py` for single-responsibility + unit-testability.
- Migrates the 9 `HTTPException` call-sites in `deps.py`, `auth.py`, `morning_notes.py`, `feedback.py` to the new contract (401/404/409/422).
- Fixes a **real bug** surfaced by the new tests: `validation_handler` called `exc.errors` (a method) instead of `exc.errors()`, silently turning every `RequestValidationError` into a 500 via the generic handler.
- Adds the fail-visible default: unregistered `PipelineError` subclasses log a distinctive line + return `500 INTERNAL_ERROR` instead of leaking.
- New tests: `tests/unit/test_errors.py` (6, no DB) and `tests/integration/test_errors.py` (5, DB) covering the translation mapping, field-grouped validation `details`, the loud default, the error-shape contract, and no-stack-trace-leak on 500s.
- Repoints 6 existing integration asserts from `{"detail": ...}` body comparisons to the `code` field.

## What this PR does NOT do

- **Does not** add the `GET /morning-notes/{id}` detail endpoint or its error handling — separate work (issue #95 branch).
- **Does not** promote the RLS-existence-hide from `404 NOT_FOUND` to `403 RLS_VIOLATION` — deliberately ambiguous, deferred (captured in plan + ADR-025 follow-up).
- **Does not** treat duplicate feedback as idempotent replay — ships `409 CONFLICT`; `IDEMPOTENCY_KEY_EXISTS` exists in `ErrorCodes` but is unused this pass.
- **Does not** distinguish "run started but not live" from "run finished" — `NO_ACTIVE_RUN` is deliberately ambiguous; a future-issue new ErrorCode was filed.

## How to verify

```bash
# Infra
docker compose up -d

# Lint + typecheck
uv run ruff check .
uv run mypy app

# Unit tests
uv run pytest tests/unit/ -q

# Integration tests (needs Postgres via docker compose)
uv run pytest tests/integration/ -q

# Error-shape smoke check against the running API
curl -s localhost:8000/morning-notes/999999999/stream -H "Authorization: Bearer <token>" | jq '{code, message, timestamp, path}'
```

Expected: `ruff` clean, `mypy` clean (53 app files), unit 82 passed, integration 79 passed.

## Decisions worth flagging

- **`NO_ACTIVE_RUN` is deliberately ambiguous** — the pipeline can't tell "run started but not live" from "run finished", so we assert no cause when none is known.
- **`translate()` default is loud** — an unmapped `PipelineError` subclass logs `"Unmapped PipelineError subclass escaped to HTTP boundary"` with `exc_type`/`exc_args` and returns 500, making a missed mapping a findable bug rather than a silent 500.
- **Translator/helpers live in `errors.py`**, not `main.py` — importable in unit tests without bootstrapping FastAPI.
- **RLS bypass stays 404** — hide-existence posture; deferred to avoid silently leaking which notes exist.
- The 3 "422" feedback tests were previously **masking the `exc.errors()` bug** — they "passed" while the server 500'd and only failed when the body-shape assert changed. The fix + the pin (`code == VALIDATION_ERROR` + field in `details`) now genuinely exercise validation.

Refs #98